### PR TITLE
Fix typo in the configuration-ray.md

### DIFF
--- a/docs/getting-started/configuring-ray.md
+++ b/docs/getting-started/configuring-ray.md
@@ -52,7 +52,7 @@ return [
     'send_dumps_to_ray' => true,
     
     /*
-     *  The url used to communicate with the Ray app.
+     *  The host used to communicate with the Ray app.
      */
     'host' => 'localhost',
     


### PR DESCRIPTION
Just to be sure no one accidentally uses a url here. Now it's also the same as in `framework agnostic projects`.