### PR TITLE
Replace include_once with include

### DIFF
--- a/src/Settings/SettingsFactory.php
+++ b/src/Settings/SettingsFactory.php
@@ -19,7 +19,7 @@ class SettingsFactory
             return [];
         }
 
-        $options = include_once $configFilePath;
+        $options = include $configFilePath;
 
         return $options;
     }


### PR DESCRIPTION
Causing tests to fail in Laravel applications when `ray.php` is used.

In Laravel tests, when Ray is re-instantiated it attempts to load the config file using `include_once`. When calling `include_once` the first time, it will work as expected. On subsequent calls within the same process it will simply return `true` to indicate that the file has already been included. https://www.php.net/manual/en/function.include-once.php

This is a problem in unit tests, as the Laravel container is destroyed and recreated for each test. The first test will run, but subsequent tests will fail as the config is set to `true` instead of the intended array.

If loading the file from disk multiple times is a concern, we could add file caching. However as this issue has only shown itself in unit tests (in my very brief testing) I'm assuming it's not expected behaviour to load settings from the config file more than once in a request/process.