### PR TITLE
fix: repeated calls to ray() throw an exception

### DIFF
--- a/src/Settings/SettingsFactory.php
+++ b/src/Settings/SettingsFactory.php
@@ -19,7 +19,7 @@ class SettingsFactory
             return [];
         }
 
-        $options = include_once $configFilePath;
+        $options = include $configFilePath;
 
         return $options;
     }

--- a/tests/SettingsTest.php
+++ b/tests/SettingsTest.php
@@ -28,6 +28,23 @@ class SettingsTest extends TestCase
         $this->assertEquals(12345, $settings->port);
         $this->assertEquals('http://otherhost', $settings->host);
     }
+    
+    /** @test */
+    public function it_can_find_the_settings_file_more_than_once()
+    {
+        $this->skipOnGitHubActions();
+        ;
+
+        $settings1 = SettingsFactory::createFromConfigFile(__DIR__ . Ray::makePathOsSafe('/testSettings/subDirectory/subSubDirectory'));
+
+        $this->assertEquals(12345, $settings1->port);
+        $this->assertEquals('http://otherhost', $settings1->host);
+        
+        $settings2 = SettingsFactory::createFromConfigFile(__DIR__ . Ray::makePathOsSafe('/testSettings/subDirectory/subSubDirectory'));
+
+        $this->assertEquals(12345, $settings2->port);
+        $this->assertEquals('http://otherhost', $settings2->host);
+    }
 
     protected function skipOnGitHubActions(): void
     {


### PR DESCRIPTION
This PR fixes an issue where only the first call in a series of repeated calls to `ray()` succeeds; the second call throws an exception.

---

Error message encountered:
```
Return value of Spatie\Ray\Settings\SettingsFactory::getSettingsFromConfigFile() must be of the type array, bool returned
  at vendor/spatie/ray/src/Settings/SettingsFactory.php:24
```

Example code to reproduce:

```php
function example()
{
    ray()->ban();
    ray()->ban();
}
```
This issue was encountered with the example code within a new Laravel project using the base `spatie/ray` package, NOT the Ray package for Laravel.

- **Cause**: the exception is caused by use of `include_once`.
- **Fix**: use `include` instead of `include_once`.

---

_Note: I have also added empty directories referenced by the existing test but that didn't exist and caused the test to fail._

Reference:

`tests/SettingsTest.php` _line 26_

`... __DIR__ . Ray::makePathOsSafe('/testSettings/subDirectory/subSubDirectory'));`

Added:

`tests/testSettings/subDirectory/subSubDirectory`
`tests/testSettings/subDirectory/subSubDirectory/.placeholder` _(empty file to force git to keep the dir)_

---

OS: Linux
PHP: 7.4.13
spatie/ray: 1.1.0.0
Laravel: 8.20.1