### PR TITLE
fix search for $indexOfRay to include calls from the parent directory

### DIFF
--- a/src/Origin/DefaultOriginFactory.php
+++ b/src/Origin/DefaultOriginFactory.php
@@ -29,7 +29,7 @@ class DefaultOriginFactory implements OriginFactory
                 return true;
             }
 
-            if ($this->startsWith($frame->file, __DIR__)) {
+            if ($this->startsWith($frame->file, dirname(__DIR__))) {
                 return true;
             }
 

--- a/tests/__snapshots__/RayTest__the_ray_function_also_works__1.json
+++ b/tests/__snapshots__/RayTest__the_ray_function_also_works__1.json
@@ -10,7 +10,7 @@
                     ]
                 },
                 "origin": {
-                    "file": "\/src\/helpers.php",
+                    "file": "\/tests\/RayTest.php",
                     "line_number": "xxx"
                 }
             }


### PR DESCRIPTION
A call from the parent directory should be marked as `$indexOfRay` as this file is located in a subdirectory.