### PR TITLE
Loosen version constraint for `ramsey/uuid` 

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         "php": "^7.4|^8.0",
         "ext-curl": "*",
         "ext-json": "*",
-        "ramsey/uuid": "^4.1",
+        "ramsey/uuid": "^3 || ^4",
         "spatie/backtrace": "^1.0",
         "spatie/macroable": "^1.0",
         "symfony/console": "^4.2|^5.2",


### PR DESCRIPTION
Adding support for `ramsey/uuid` v3 is suggested in https://uuid.ramsey.dev/en/latest/upgrading/3-to-4.html
> This will allow any downstream users of your project who aren’t ready to upgrade to version 4 the ability to continue using your project while deciding on an appropriate upgrade schedule.

Tested by setting the version constraint of `ramsey/uuid` to only allow v3 and running the tests.
