### PR TITLE
Prepare composer, assign type of wordpress-plugin

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,88 +1,69 @@
 {
-    "name": "laravel/laravel",
-    "type": "project",
-    "description": "The Laravel Framework.",
+    "name": "spatie/ray",
+	"type": "wordpress-plugin",
+    "description": "Debug with Ray to fix problems faster",
     "keywords": [
-        "framework",
-        "laravel"
+        "spatie",
+        "ray"
     ],
+    "homepage": "https://github.com/spatie/ray",
     "license": "MIT",
+    "authors": [
+        {
+            "name": "Freek Van der Herten",
+            "email": "freek@spatie.be",
+            "homepage": "https://spatie.be",
+            "role": "Developer"
+        }
+    ],
     "require": {
-        "php": "^7.4",
-        "blade-ui-kit/blade-ui-kit": "^0.1.1",
-        "dyrynda/laravel-efficient-uuid": "^4.2",
-        "dyrynda/laravel-model-uuid": "^6.3",
-        "fideloper/proxy": "^4.2",
-        "fruitcake/laravel-cors": "^2.0",
-        "grimzy/laravel-mysql-spatial": "^5.0",
-        "guzzlehttp/guzzle": "^7.0.1",
-        "laravel-lang/lang": "~7.0",
-        "laravel/framework": "^8.0",
-        "laravel/jetstream": "^1.4",
-        "laravel/sanctum": "^2.6",
-        "laravel/tinker": "^2.0",
-        "league/commonmark": "^1.4",
-        "livewire/livewire": "^2.0",
-        "spatie/laravel-activitylog": "^3.16",
-        "spatie/laravel-enum": "^2.0",
-        "spatie/laravel-json-api-paginate": "^1.10",
-        "spatie/laravel-medialibrary": "^9.0.0",
-        "spatie/laravel-query-builder": "^3.3",
-        "spatie/laravel-schemaless-attributes": "^1.8",
-        "spatie/laravel-sluggable": "^2.5",
-        "spatie/laravel-tags": "^3.0"
+        "php": "^7.4|^8.0",
+        "ext-curl": "*",
+        "ext-json": "*",
+        "composer/installers": "~1.0",
+        "ramsey/uuid": "^3.0|^4.1",
+        "spatie/backtrace": "^1.0",
+        "spatie/macroable": "^1.0",
+        "symfony/console": "^4.2|^5.2",
+        "symfony/stopwatch": "^4.2|^5.2",
+        "symfony/var-dumper": "^4.2|^5.2"
     },
     "require-dev": {
-        "barryvdh/laravel-debugbar": "^3.5",
-        "barryvdh/laravel-ide-helper": "^2.8",
-        "beyondcode/helo-laravel": "^1.1",
-        "facade/ignition": "^2.3.6",
-        "fzaninotto/faker": "^1.9.1",
-        "knuckleswtf/scribe": "^1.9",
-        "laracasts/generators": "^2.0",
-        "mockery/mockery": "^1.3.1",
-        "nunomaduro/collision": "^5.0",
-        "phpunit/phpunit": "^9.3"
-    },
-    "config": {
-        "optimize-autoloader": true,
-        "preferred-install": "dist",
-        "sort-packages": true
-    },
-    "extra": {
-        "laravel": {
-            "dont-discover": []
-        }
+        "illuminate/support": "^8.18",
+        "phpunit/phpunit": "^9.5",
+        "spatie/phpunit-snapshot-assertions": "^4.2"
     },
     "autoload": {
         "psr-4": {
-            "App\\": "app/",
-            "Database\\Factories\\": "database/factories/",
-            "Database\\Seeders\\": "database/seeders/"
-        }
+            "Spatie\\Ray\\": "src"
+        },
+        "files": [
+            "src/helpers.php"
+        ]
     },
     "autoload-dev": {
         "psr-4": {
-            "Tests\\": "tests/"
+            "Spatie\\Ray\\Tests\\": "tests"
         }
+    },
+    "scripts": {
+        "test": "vendor/bin/phpunit",
+        "test-coverage": "vendor/bin/phpunit --coverage-html coverage",
+        "format": "vendor/bin/php-cs-fixer fix --allow-risky=yes"
+    },
+    "config": {
+        "sort-packages": true
     },
     "minimum-stability": "dev",
     "prefer-stable": true,
-    "scripts": {
-        "post-autoload-dump": [
-            "Illuminate\\Foundation\\ComposerScripts::postAutoloadDump",
-            "@php artisan package:discover --ansi"
-        ],
-        "post-root-package-install": [
-            "@php -r \"file_exists('.env') || copy('.env.example', '.env');\""
-        ],
-        "post-create-project-cmd": [
-            "@php artisan key:generate --ansi"
-        ],
-        "post-update-cmd": [
-            "Illuminate\\Foundation\\ComposerScripts::postUpdate",
-            "@php artisan ide-helper:generate",
-            "@php artisan ide-helper:meta"
-        ]
-    }
+    "funding": [
+        {
+            "type": "github",
+            "url": "https://github.com/sponsors/spatie"
+        },
+        {
+            "type": "other",
+            "url": "https://spatie.be/open-source/support-us"
+        }
+    ]
 }

--- a/composer.json
+++ b/composer.json
@@ -1,67 +1,88 @@
 {
-    "name": "spatie/ray",
-    "description": "Debug with Ray to fix problems faster",
+    "name": "laravel/laravel",
+    "type": "project",
+    "description": "The Laravel Framework.",
     "keywords": [
-        "spatie",
-        "ray"
+        "framework",
+        "laravel"
     ],
-    "homepage": "https://github.com/spatie/ray",
     "license": "MIT",
-    "authors": [
-        {
-            "name": "Freek Van der Herten",
-            "email": "freek@spatie.be",
-            "homepage": "https://spatie.be",
-            "role": "Developer"
-        }
-    ],
     "require": {
-        "php": "^7.4|^8.0",
-        "ext-curl": "*",
-        "ext-json": "*",
-        "ramsey/uuid": "^3.0|^4.1",
-        "spatie/backtrace": "^1.0",
-        "spatie/macroable": "^1.0",
-        "symfony/console": "^4.2|^5.2",
-        "symfony/stopwatch": "^4.2|^5.2",
-        "symfony/var-dumper": "^4.2|^5.2"
+        "php": "^7.4",
+        "blade-ui-kit/blade-ui-kit": "^0.1.1",
+        "dyrynda/laravel-efficient-uuid": "^4.2",
+        "dyrynda/laravel-model-uuid": "^6.3",
+        "fideloper/proxy": "^4.2",
+        "fruitcake/laravel-cors": "^2.0",
+        "grimzy/laravel-mysql-spatial": "^5.0",
+        "guzzlehttp/guzzle": "^7.0.1",
+        "laravel-lang/lang": "~7.0",
+        "laravel/framework": "^8.0",
+        "laravel/jetstream": "^1.4",
+        "laravel/sanctum": "^2.6",
+        "laravel/tinker": "^2.0",
+        "league/commonmark": "^1.4",
+        "livewire/livewire": "^2.0",
+        "spatie/laravel-activitylog": "^3.16",
+        "spatie/laravel-enum": "^2.0",
+        "spatie/laravel-json-api-paginate": "^1.10",
+        "spatie/laravel-medialibrary": "^9.0.0",
+        "spatie/laravel-query-builder": "^3.3",
+        "spatie/laravel-schemaless-attributes": "^1.8",
+        "spatie/laravel-sluggable": "^2.5",
+        "spatie/laravel-tags": "^3.0"
     },
     "require-dev": {
-        "illuminate/support": "^8.18",
-        "phpunit/phpunit": "^9.5",
-        "spatie/phpunit-snapshot-assertions": "^4.2"
+        "barryvdh/laravel-debugbar": "^3.5",
+        "barryvdh/laravel-ide-helper": "^2.8",
+        "beyondcode/helo-laravel": "^1.1",
+        "facade/ignition": "^2.3.6",
+        "fzaninotto/faker": "^1.9.1",
+        "knuckleswtf/scribe": "^1.9",
+        "laracasts/generators": "^2.0",
+        "mockery/mockery": "^1.3.1",
+        "nunomaduro/collision": "^5.0",
+        "phpunit/phpunit": "^9.3"
+    },
+    "config": {
+        "optimize-autoloader": true,
+        "preferred-install": "dist",
+        "sort-packages": true
+    },
+    "extra": {
+        "laravel": {
+            "dont-discover": []
+        }
     },
     "autoload": {
         "psr-4": {
-            "Spatie\\Ray\\": "src"
-        },
-        "files": [
-            "src/helpers.php"
-        ]
+            "App\\": "app/",
+            "Database\\Factories\\": "database/factories/",
+            "Database\\Seeders\\": "database/seeders/"
+        }
     },
     "autoload-dev": {
         "psr-4": {
-            "Spatie\\Ray\\Tests\\": "tests"
+            "Tests\\": "tests/"
         }
-    },
-    "scripts": {
-        "test": "vendor/bin/phpunit",
-        "test-coverage": "vendor/bin/phpunit --coverage-html coverage",
-        "format": "vendor/bin/php-cs-fixer fix --allow-risky=yes"
-    },
-    "config": {
-        "sort-packages": true
     },
     "minimum-stability": "dev",
     "prefer-stable": true,
-    "funding": [
-        {
-            "type": "github",
-            "url": "https://github.com/sponsors/spatie"
-        },
-        {
-            "type": "other",
-            "url": "https://spatie.be/open-source/support-us"
-        }
-    ]
+    "scripts": {
+        "post-autoload-dump": [
+            "Illuminate\\Foundation\\ComposerScripts::postAutoloadDump",
+            "@php artisan package:discover --ansi"
+        ],
+        "post-root-package-install": [
+            "@php -r \"file_exists('.env') || copy('.env.example', '.env');\""
+        ],
+        "post-create-project-cmd": [
+            "@php artisan key:generate --ansi"
+        ],
+        "post-update-cmd": [
+            "Illuminate\\Foundation\\ComposerScripts::postUpdate",
+            "@php artisan ide-helper:generate",
+            "@php artisan ide-helper:meta"
+        ]
+    }
 }


### PR DESCRIPTION
This way when installing this in a composer-based WP project (eg. Bedrock) - it will know it's a plugin and install the folder correctly under the wp-content/plugins directory.

[ref. [daggerhartlab.com/how-to-setup-wordpress-plugin-composer-packagist](https://www.daggerhartlab.com/how-to-setup-wordpress-plugin-composer-packagist/)]