### PR TITLE
Add `env()` calls to the Laravel `ray.php` config docs

### DIFF
--- a/docs/getting-started/configuring-ray.md
+++ b/docs/getting-started/configuring-ray.md
@@ -48,42 +48,56 @@ php artisan ray:publish-config --docker
 php artisan ray:publish-config --homestead
 ```
 
-Alternatively for Laravel projects you can create a ray.php file and use the following template:
+Alternatively for Laravel projects you can create a `ray.php` file in your project directory (not in the `config` directory) using the following template.
+
+You can use [Laravel environment variables](https://laravel.com/docs/master/configuration#environment-configuration) to change the configuration values, if desired. Doing so can make it easier for your fellow developers to use their own configuration.
 
 ```php
 // save this in a file called "ray.php" in the root directory of your project; not in the Laravel "config" directory
 
 return [
     /*
-     * This settings controls whether data should be sent to Ray.
-     * 
-     * By default, `ray()` will only transmit data in non-production environments.
-     */
-    'enable' => true,
+    * This settings controls whether data should be sent to Ray.
+    *
+    * By default, `ray()` will only transmit data in non-production environments.
+    */
+    'enable' => env('RAY_ENABLED', true),
 
     /*
-     * When enabled, all things logged to the application log
-     * will be sent to Ray as well.
-     */
-    'send_log_calls_to_ray' => true,
+    * When enabled, all things logged to the application log
+    * will be sent to Ray as well.
+    */
+    'send_log_calls_to_ray' => env('SEND_LOG_CALLS_TO_RAY', true),
 
     /*
-     * When enabled, all things passed to `dump` or `dd`
-     * will be sent to Ray as well.
-     */
-    'send_dumps_to_ray' => true,
-    
+    * When enabled, all things passed to `dump` or `dd`
+    * will be sent to Ray as well.
+    */
+    'send_dumps_to_ray' => env('SEND_DUMPS_TO_RAY', true),
+
     /*
-     * The host used to communicate with the Ray app.
-     * For usage in Docker on Mac or Windows, you can replace host with 'host.docker.internal'
-     * For usage in Homestead on Mac or Windows, you can replace host with '10.0.2.2'
-     */
-    'host' => 'localhost',
-    
+    * The host used to communicate with the Ray app.
+    * For usage in Docker on Mac or Windows, you can replace host with 'host.docker.internal'
+    * For usage in Homestead on Mac or Windows, you can replace host with '10.0.2.2'
+    */
+    'host' => env('RAY_HOST', 'localhost'),
+
     /*
-     * The port number used to communicate with the Ray app. 
+    * The port number used to communicate with the Ray app.
+    */
+    'port' => env('RAY_PORT', 23517),
+
+    /*
+     * Absolute base path for your sites or projects in Homestead,
+     * Vagrant, Docker, or another remote development server.
      */
-    'port' => 23517,
+    'remote_path' => env('RAY_REMOTE_PATH', null),
+
+    /*
+     * Absolute base path for your sites or projects on your local
+     * computer where your IDE or code editor is running on.
+     */
+    'local_path' => env('RAY_LOCAL_PATH', null),
 ];
 ```
 


### PR DESCRIPTION
This adds docs for the changes made in [PR #55 in the laravel-ray repo](https://github.com/spatie/laravel-ray/pull/55).