### PR TITLE
Send file contents

### DIFF
--- a/docs/usage/framework-agnostic-php-project.md
+++ b/docs/usage/framework-agnostic-php-project.md
@@ -158,6 +158,14 @@ ray()->json($jsonString);
 
 ![screenshot](/docs/ray/v1/images/json.png)
 
+### Working with files
+
+You can display the contents of any file in Ray with the `file` function.
+
+```php
+ray()->file('somefile.txt');
+```
+
 ### Updating displayed items
 
 You can update values that are already displayed in Ray. To do this, you must hold on the instance returned by the `ray` function and call send on it.

--- a/src/Payloads/FileContentsPayload.php
+++ b/src/Payloads/FileContentsPayload.php
@@ -4,11 +4,11 @@ namespace Spatie\Ray\Payloads;
 
 class FileContentsPayload extends Payload
 {
-    protected string $filename;
+    protected string $file;
 
-    public function __construct(string $filename)
+    public function __construct(string $file)
     {
-        $this->filename = $filename;
+        $this->file = $file;
     }
 
     public function getType(): string
@@ -18,18 +18,18 @@ class FileContentsPayload extends Payload
 
     public function getContent(): array
     {
-        if (!file_exists($this->filename)) {
-            $contents = "file not found: '{$this->filename}'";
-            $label = null;
-        } else {
-            $contents = file_get_contents($this->filename);
-            $contents = nl2br(htmlentities($contents));
-            $label = basename($this->filename);
+        if (!file_exists($this->file)) {
+            return [
+                'content' => "File not found: '{$this->file}'",
+                'label' => 'File',
+            ];
         }
 
+        $contents = file_get_contents($this->file);
+
         return [
-            'content' => $contents,
-            'label' => $label,
+            'content' => nl2br(htmlentities($contents)),
+            'label' => basename($this->file),
         ];
     }
 }

--- a/src/Payloads/FileContentsPayload.php
+++ b/src/Payloads/FileContentsPayload.php
@@ -24,7 +24,7 @@ class FileContentsPayload extends Payload
         } else {
             $contents = file_get_contents($this->filename);
             $contents = nl2br(htmlentities($contents));
-            $label = realpath($this->filename);
+            $label = basename($this->filename);
         }
 
         return [

--- a/src/Payloads/FileContentsPayload.php
+++ b/src/Payloads/FileContentsPayload.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Spatie\Ray\Payloads;
+
+class FileContentsPayload extends Payload
+{
+    protected string $filename;
+
+    public function __construct(string $filename)
+    {
+        $this->filename = $filename;
+    }
+
+    public function getType(): string
+    {
+        return 'custom';
+    }
+
+    public function getContent(): array
+    {
+        if (!file_exists($this->filename)) {
+            $contents = "file not found: '{$this->filename}'";
+            $label = null;
+        } else {
+            $contents = file_get_contents($this->filename);
+            $contents = nl2br(htmlentities($contents));
+            $label = realpath($this->filename);
+        }
+
+        return [
+            'content' => $contents,
+            'label' => $label,
+        ];
+    }
+}

--- a/src/Payloads/FileContentsPayload.php
+++ b/src/Payloads/FileContentsPayload.php
@@ -28,8 +28,16 @@ class FileContentsPayload extends Payload
         $contents = file_get_contents($this->file);
 
         return [
-            'content' => nl2br(htmlentities($contents)),
+            'content' => $this->encodeContent($contents),
             'label' => basename($this->file),
         ];
+    }
+
+    protected function encodeContent(string $content): string
+    {
+        $result = htmlentities($content);
+
+        // using nl2br() causes tests to fail on windows, so use <br> only
+        return str_replace(PHP_EOL, '<br />', $result);
     }
 }

--- a/src/Ray.php
+++ b/src/Ray.php
@@ -235,9 +235,6 @@ class Ray
         return $this->sendRequest($payload);
     }
 
-    /**
-     * Sends the contents of the specified file.
-     */
     public function file(string $filename): self
     {
         $payload = new FileContentsPayload($filename);

--- a/src/Ray.php
+++ b/src/Ray.php
@@ -15,6 +15,7 @@ use Spatie\Ray\Payloads\ColorPayload;
 use Spatie\Ray\Payloads\CreateLockPayload;
 use Spatie\Ray\Payloads\CustomPayload;
 use Spatie\Ray\Payloads\DecodedJsonPayload;
+use Spatie\Ray\Payloads\FileContentsPayload;
 use Spatie\Ray\Payloads\HidePayload;
 use Spatie\Ray\Payloads\JsonStringPayload;
 use Spatie\Ray\Payloads\LogPayload;
@@ -230,6 +231,16 @@ class Ray
     public function json(string $json): self
     {
         $payload = new DecodedJsonPayload($json);
+
+        return $this->sendRequest($payload);
+    }
+
+    /**
+     * Sends the contents of the specified file.
+     */
+    public function file(string $filename): self
+    {
+        $payload = new FileContentsPayload($filename);
 
         return $this->sendRequest($payload);
     }

--- a/tests/RayTest.php
+++ b/tests/RayTest.php
@@ -269,7 +269,7 @@ class RayTest extends TestCase
 
         $this->assertMatchesOsSafeSnapshot($this->client->sentPayloads());
     }
-    
+
     /** @test */
     public function it_can_send_the_json_payload()
     {
@@ -280,12 +280,20 @@ class RayTest extends TestCase
         $this->assertStringContainsString('<span class=sf-dump-key>message</span>', $dumpedValue);
         $this->assertStringContainsString('<span class=sf-dump-str title="14 characters">message text 2</span>', $dumpedValue);
     }
-    
+
     /** @test */
     public function it_can_send_the_toJson_payload()
     {
         $this->ray->toJson(['message' => 'message text 1']);
-        
+
+        $this->assertMatchesOsSafeSnapshot($this->client->sentPayloads());
+    }
+
+    /** @test */
+    public function it_can_send_the_file_content_payload()
+    {
+        $this->ray->file(__DIR__ .'/testSettings/ray.php');
+
         $this->assertMatchesOsSafeSnapshot($this->client->sentPayloads());
     }
 

--- a/tests/__snapshots__/RayTest__it_can_send_the_file_content_payload__1.json
+++ b/tests/__snapshots__/RayTest__it_can_send_the_file_content_payload__1.json
@@ -5,7 +5,7 @@
             {
                 "type": "custom",
                 "content": {
-                    "content": "&lt;?php<br \/>\n<br \/>\nreturn [<br \/>\n    'port' =&gt; 12345,<br \/>\n<br \/>\n    'host' =&gt; 'http:\/\/otherhost',<br \/>\n];<br \/>\n",
+                    "content": "&lt;?php<br \/><br \/>return [<br \/>    'port' =&gt; 12345,<br \/><br \/>    'host' =&gt; 'http:\/\/otherhost',<br \/>];<br \/>",
                     "label": "ray.php"
                 },
                 "origin": {

--- a/tests/__snapshots__/RayTest__it_can_send_the_file_content_payload__1.json
+++ b/tests/__snapshots__/RayTest__it_can_send_the_file_content_payload__1.json
@@ -6,7 +6,7 @@
                 "type": "custom",
                 "content": {
                     "content": "&lt;?php<br \/>\n<br \/>\nreturn [<br \/>\n    'port' =&gt; 12345,<br \/>\n<br \/>\n    'host' =&gt; 'http:\/\/otherhost',<br \/>\n];<br \/>\n",
-                    "label": "\/development\/repositories\/ray\/tests\/testSettings\/ray.php"
+                    "label": "ray.php"
                 },
                 "origin": {
                     "file": "\/tests\/RayTest.php",

--- a/tests/__snapshots__/RayTest__it_can_send_the_file_content_payload__1.json
+++ b/tests/__snapshots__/RayTest__it_can_send_the_file_content_payload__1.json
@@ -1,0 +1,19 @@
+[
+    {
+        "uuid": "fakeUuid",
+        "payloads": [
+            {
+                "type": "custom",
+                "content": {
+                    "content": "&lt;?php<br \/>\n<br \/>\nreturn [<br \/>\n    'port' =&gt; 12345,<br \/>\n<br \/>\n    'host' =&gt; 'http:\/\/otherhost',<br \/>\n];<br \/>\n",
+                    "label": "\/development\/repositories\/ray\/tests\/testSettings\/ray.php"
+                },
+                "origin": {
+                    "file": "\/tests\/RayTest.php",
+                    "line_number": "xxx"
+                }
+            }
+        ],
+        "meta": []
+    }
+]


### PR DESCRIPTION
This PR adds the `file()` method, which accepts a filename as its only parameter and sends the contents of the file to Ray.  This method also sends a label containing the filename along with the payload.
Note: The file content is encoded with `htmlentities()` and `nl2br()` to ensure HTML files are displayed correctly.

Developers will find this addition very helpful when working with the file system and need to debug multiple files quickly.

Unit tests and documentation have been added.