### PR TITLE
Prevent possible memory leak

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -20,21 +20,23 @@ class Client
 
     public function send(Request $request): void
     {
-        $curlHandle = $this->getCurlHandleForUrl('get', '');
+        try {
+            $curlHandle = $this->getCurlHandleForUrl('get', '');
 
-        $curlError = null;
+            $curlError = null;
 
-        curl_setopt($curlHandle, CURLOPT_POSTFIELDS, $request->toJson());
-        curl_exec($curlHandle);
+            curl_setopt($curlHandle, CURLOPT_POSTFIELDS, $request->toJson());
+            curl_exec($curlHandle);
 
-        if (curl_errno($curlHandle)) {
-            $curlError = curl_error($curlHandle);
-        }
+            if (curl_errno($curlHandle)) {
+                $curlError = curl_error($curlHandle);
+            }
 
-        curl_close($curlHandle);
-
-        if ($curlError) {
-            // do nothing for now
+            if ($curlError) {
+                // do nothing for now
+            }
+        } finally {
+            curl_close($curlHandle);
         }
     }
 
@@ -49,8 +51,6 @@ class Client
             if (curl_errno($curlHandle)) {
                 $curlError = curl_error($curlHandle);
             }
-
-            curl_close($curlHandle);
 
             if ($curlError) {
                 throw new Exception;
@@ -71,6 +71,8 @@ class Client
             if ($exception instanceof StopExecutionRequested) {
                 throw $exception;
             }
+        } finally {
+            curl_close($curlHandle);
         }
 
         return false;


### PR DESCRIPTION
This PR adds `try`/`finally `blocks to s avoid possible (but unlikely) memory leak related to not freeing the resource handle returned by `curl_init()`.  In rare situations, `curl_close()` could fail to be called, resulting in a memory leak.

This ensures that `curl_close()` is always called.