### PR TITLE
Support multiple arguments to `toJson()` and `json()`

### DIFF
--- a/docs/usage/framework-agnostic-php-project.md
+++ b/docs/usage/framework-agnostic-php-project.md
@@ -138,7 +138,7 @@ ray()->measure(function() {
 
 ### Working with JSON
 
-Want to display the json representation of anything you'd like in Ray? Use `toJson`
+Want to display the JSON representation of anything you'd like in Ray? Use `toJson`. You can provide any value that can be converted to JSON with [json_encode](https://www.php.net/json_encode).
 
 ```php
 ray()->toJson(['a' => 1, 'b' => ['c' => 3]]);
@@ -146,7 +146,21 @@ ray()->toJson(['a' => 1, 'b' => ['c' => 3]]);
 
 ![screenshot](/docs/ray/v1/images/to-json.png)
 
-You can send valid JSON to Ray with the `json` function.
+The `toJson` function can also accept multiple arguments.
+
+```php
+// all of these will be displayed in Ray
+$object = new \stdClass();
+$object->company = 'Spatie';
+
+ray()->toJson(
+    ['a' => 1, 'b' => ['c' => 3]],
+    ['d' => ['e' => 5]],
+    $object
+);
+```
+
+You can send a valid JSON string to Ray with the `json` function.
 
 It will be displayed nicely and collapsable in Ray.
 
@@ -157,6 +171,13 @@ ray()->json($jsonString);
 ```
 
 ![screenshot](/docs/ray/v1/images/json.png)
+
+The `json` function can also accept multiple valid JSON strings.
+
+```php
+// all of these will be displayed in Ray
+ray()->json($jsonString, $anotherJsonString, $yetAnotherJsonString);
+```
 
 ### Working with files
 

--- a/src/Ray.php
+++ b/src/Ray.php
@@ -217,23 +217,27 @@ class Ray
     }
 
     /**
-     * Sends the provided value encoded as a JSON string using json_encode().
+     * Sends the provided value(s) encoded as a JSON string using json_encode().
      */
-    public function toJson($value): self
+    public function toJson(...$values): self
     {
-        $payload = new JsonStringPayload($value);
+        $payloads = array_map(function ($value) {
+            return new JsonStringPayload($value);
+        }, $values);
 
-        return $this->sendRequest($payload);
+        return $this->sendRequest($payloads);
     }
 
     /**
-     * Sends the provided JSON string decoded using json_decode().
+     * Sends the provided JSON string(s) decoded using json_decode().
      */
-    public function json(string $json): self
+    public function json(string ...$jsons): self
     {
-        $payload = new DecodedJsonPayload($json);
+        $payloads = array_map(function ($json) {
+            return new DecodedJsonPayload($json);
+        }, $jsons);
 
-        return $this->sendRequest($payload);
+        return $this->sendRequest($payloads);
     }
 
     public function file(string $filename): self

--- a/tests/RayTest.php
+++ b/tests/RayTest.php
@@ -282,9 +282,37 @@ class RayTest extends TestCase
     }
 
     /** @test */
+    public function it_can_send_multiple_json_payloads()
+    {
+        $this->ray->json(
+            '{"message": "message text 1"}',
+            '{"message": "message text 2"}'
+        );
+
+        $dumpedValue1 = $this->client->sentPayloads()[0]['payloads'][0]['content']['content'];
+        $dumpedValue2 = $this->client->sentPayloads()[0]['payloads'][1]['content']['content'];
+
+        $this->assertStringContainsString('<span class=sf-dump-key>message</span>', $dumpedValue1);
+        $this->assertStringContainsString('<span class=sf-dump-key>message</span>', $dumpedValue2);
+        $this->assertStringContainsString('<span class=sf-dump-str title="14 characters">message text 1</span>', $dumpedValue1);
+        $this->assertStringContainsString('<span class=sf-dump-str title="14 characters">message text 2</span>', $dumpedValue2);
+    }
+
+    /** @test */
     public function it_can_send_the_toJson_payload()
     {
         $this->ray->toJson(['message' => 'message text 1']);
+
+        $this->assertMatchesOsSafeSnapshot($this->client->sentPayloads());
+    }
+
+    /** @test */
+    public function it_can_send_multiple_toJson_payloads()
+    {
+        $this->ray->toJson(
+            ['message' => 'message text 1'],
+            ['message' => 'message text 2']
+        );
 
         $this->assertMatchesOsSafeSnapshot($this->client->sentPayloads());
     }

--- a/tests/__snapshots__/RayTest__it_can_send_multiple_toJson_payloads__1.json
+++ b/tests/__snapshots__/RayTest__it_can_send_multiple_toJson_payloads__1.json
@@ -1,0 +1,28 @@
+[
+    {
+        "uuid": "fakeUuid",
+        "payloads": [
+            {
+                "type": "json_string",
+                "content": {
+                    "value": "{\"message\":\"message text 1\"}"
+                },
+                "origin": {
+                    "file": "\/tests\/RayTest.php",
+                    "line_number": "xxx"
+                }
+            },
+            {
+                "type": "json_string",
+                "content": {
+                    "value": "{\"message\":\"message text 2\"}"
+                },
+                "origin": {
+                    "file": "\/tests\/RayTest.php",
+                    "line_number": "xxx"
+                }
+            }
+        ],
+        "meta": []
+    }
+]


### PR DESCRIPTION
FYI I also made a minor tweak to the first paragraph in the "Working with JSON" section that adds clarity around what types of values can be provided to `toJson`.