### PR TITLE
Success/Failure Statuses

### DIFF
--- a/docs/usage/framework-agnostic-php-project.md
+++ b/docs/usage/framework-agnostic-php-project.md
@@ -48,6 +48,15 @@ ray('large')->large();
 
 ![screenshot](/docs/ray/v1/images/sizes.jpg)
 
+### Setting statuses
+
+You can set the background color of a Ray entry to indicate a status one of the status functions.
+
+```php
+ray('successful')->success();
+ray('failed')->failure();
+```
+
 ### Creating a new screen
 
 You can use `newScreen` (or `clearScreen`) to programmatically create a new screen.
@@ -135,7 +144,7 @@ Here's an example:
 
     foreach (range(1, 2) as $j) {
         ray()->count('first');
-        
+
         ray()->count('second');
     }
 }

--- a/src/Concerns/RayStatuses.php
+++ b/src/Concerns/RayStatuses.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Spatie\Ray\Concerns;
+
+/** @mixin \Spatie\Ray\Ray */
+trait RayStatuses
+{
+    public function success(): self
+    {
+        return $this->status('success');
+    }
+
+    public function failure(): self
+    {
+        return $this->status('failure');
+    }
+}

--- a/src/Payloads/StatusPayload.php
+++ b/src/Payloads/StatusPayload.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Spatie\Ray\Payloads;
+
+class StatusPayload extends Payload
+{
+    /** @var mixed */
+    protected $type;
+
+    public function __construct(string $type)
+    {
+        $this->type = $type;
+    }
+
+    public function getType(): string
+    {
+        return 'color';
+    }
+
+    public function getContent(): array
+    {
+        return [
+            'color' => $this->typeColor(),
+        ];
+    }
+
+    protected function typeColor(): string
+    {
+        if ($this->type === 'success') {
+            return 'green-600 bg-green';
+        }
+
+        if ($this->type === 'failure') {
+            return 'red-600 bg-red';
+        }
+
+        // leading & trailing spaces are required
+        return ' transparent ';
+    }
+}

--- a/src/Ray.php
+++ b/src/Ray.php
@@ -11,12 +11,14 @@ use Spatie\LaravelRay\Ray as LaravelRay;
 use Spatie\Macroable\Macroable;
 use Spatie\Ray\Concerns\RayColors;
 use Spatie\Ray\Concerns\RaySizes;
+use Spatie\Ray\Concerns\RayStatuses;
 use Spatie\Ray\Origin\DefaultOriginFactory;
 use Spatie\Ray\Payloads\CallerPayload;
 use Spatie\Ray\Payloads\ColorPayload;
 use Spatie\Ray\Payloads\CreateLockPayload;
 use Spatie\Ray\Payloads\CustomPayload;
 use Spatie\Ray\Payloads\DecodedJsonPayload;
+use Spatie\Ray\Payloads\StatusPayload;
 use Spatie\Ray\Payloads\FileContentsPayload;
 use Spatie\Ray\Payloads\HidePayload;
 use Spatie\Ray\Payloads\JsonStringPayload;
@@ -36,6 +38,7 @@ class Ray
 {
     use RayColors;
     use RaySizes;
+    use RayStatuses;
     use Macroable;
 
     public Settings $settings;
@@ -91,6 +94,15 @@ class Ray
     public function color(string $color): self
     {
         $payload = new ColorPayload($color);
+
+        $this->sendRequest($payload);
+
+        return $this;
+    }
+
+    public function status(string $status): self
+    {
+        $payload = new StatusPayload($status);
 
         $this->sendRequest($payload);
 

--- a/tests/Concerns/ConcernsTest.php
+++ b/tests/Concerns/ConcernsTest.php
@@ -5,9 +5,17 @@ namespace Spatie\Ray\Tests\Concerns;
 
 use PHPUnit\Framework\TestCase;
 use Spatie\Ray\Tests\TestClasses\FakeRay;
+use Spatie\Snapshots\MatchesSnapshots;
 
 class ConcernsTest extends TestCase
 {
+    use MatchesSnapshots;
+
+    protected function assertMatchesOsSafeSnapshot($data)
+    {
+        $this->assertMatchesJsonSnapshot(json_encode($data));
+    }
+
     /** @test */
     public function it_sets_small_and_large_payload_sizes()
     {
@@ -36,5 +44,25 @@ class ConcernsTest extends TestCase
         }
 
         $this->assertEquals($colors, $ray->getColorHistory());
+    }
+
+    /** @test */
+    public function it_sets_success_and_failure_statuses()
+    {
+        $ray = new FakeRay();
+
+        $statuses = ['success', 'failure'];
+
+        foreach($statuses as $status) {
+            $ray->status($status);
+            $this->assertEquals($status, $ray->getLastStatus());
+
+            $ray->status('reset');
+
+            $ray->{$status}();
+            $this->assertEquals($status, $ray->getLastStatus());
+        }
+
+        $this->assertMatchesOsSafeSnapshot($ray->getStatusHistory());
     }
 }

--- a/tests/Concerns/__snapshots__/ConcernsTest__it_sets_success_and_failure_statuses__1.json
+++ b/tests/Concerns/__snapshots__/ConcernsTest__it_sets_success_and_failure_statuses__1.json
@@ -1,0 +1,8 @@
+[
+    "success",
+    "reset",
+    "success",
+    "failure",
+    "reset",
+    "failure"
+]

--- a/tests/TestClasses/FakeRay.php
+++ b/tests/TestClasses/FakeRay.php
@@ -5,19 +5,23 @@ namespace Spatie\Ray\Tests\TestClasses;
 
 use Spatie\Ray\Concerns\RayColors;
 use Spatie\Ray\Concerns\RaySizes;
+use Spatie\Ray\Concerns\RayStatuses;
 
 class FakeRay
 {
     use RaySizes;
     use RayColors;
+    use RayStatuses;
 
     protected array $sizeHistory;
     protected array $colorHistory;
+    protected array $statusHistory;
 
     public function __construct()
     {
-        $this->sizeHistory = [];
         $this->colorHistory = [];
+        $this->sizeHistory = [];
+        $this->statusHistory = [];
     }
 
     public function size(string $size): self
@@ -34,6 +38,13 @@ class FakeRay
         return $this;
     }
 
+    public function status(string $status): self
+    {
+        $this->statusHistory[] = $status;
+
+        return $this;
+    }
+
     public function getSizeHistory(): array
     {
         return $this->sizeHistory;
@@ -42,6 +53,11 @@ class FakeRay
     public function getColorHistory(): array
     {
         return $this->colorHistory;
+    }
+
+    public function getStatusHistory(): array
+    {
+        return $this->statusHistory;
     }
 
     public function getLastSize(): string
@@ -54,11 +70,17 @@ class FakeRay
         return $this->colorHistory[count($this->colorHistory) - 1];
     }
 
+    public function getLastStatus(): string
+    {
+        return $this->statusHistory[count($this->statusHistory) - 1];
+    }
+
     public function setPayloads(): array
     {
         return [
             'colors' => $this->colorHistory,
             'sizes' => $this->sizeHistory,
+            'statuses' => $this->statusHistory,
         ];
     }
 }


### PR DESCRIPTION
This PR adds `status()`, `success()` and `failure()` methods that help developers ascertain the success/failure status of an action at a glance.  Although more drastic than calling a `color()` method, the new methods will result in a quality-of-life increase for developers, especially when scanning through a large number of Ray entries.

The `success()` method sets the background color of the Ray entry to green, and `failure()` sets it to red:

![image](https://user-images.githubusercontent.com/5508707/104713580-1471aa80-56f2-11eb-9f1b-ceff870c4f15.png)

Documentation and unit tests have been included.