### PR TITLE
Image payload

### DIFF
--- a/docs/usage/framework-agnostic-php-project.md
+++ b/docs/usage/framework-agnostic-php-project.md
@@ -135,7 +135,7 @@ Here's an example:
 
     foreach (range(1, 2) as $j) {
         ray()->count('first');
-        
+
         ray()->count('second');
     }
 }
@@ -233,6 +233,15 @@ You can display the contents of any file in Ray with the `file` function.
 
 ```php
 ray()->file('somefile.txt');
+```
+
+### Displaying images
+
+To display an image, call the `image` function and pass either a fully-qualified filename or url as its only argument.
+
+```php
+ray()->image('https://placekitten.com/200/300');
+ray()->image('/home/auser/kitten.jpg');
 ```
 
 ### Updating displayed items

--- a/src/Payloads/ImagePayload.php
+++ b/src/Payloads/ImagePayload.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Spatie\Ray\Payloads;
+
+class ImagePayload extends Payload
+{
+    protected string $location;
+
+    public function __construct(string $location)
+    {
+        $this->location = $location;
+    }
+
+    public function getType(): string
+    {
+        return 'custom';
+    }
+
+    public function getContent(): array
+    {
+        if (file_exists($this->location)) {
+            $this->location = 'file://' . $this->location;
+        }
+
+        $location = str_replace('"', '', $this->location);
+
+        return [
+            'content' => "<img src=\"{$location}\" alt=\"\" />",
+            'label' => 'Image',
+        ];
+    }
+}

--- a/src/Ray.php
+++ b/src/Ray.php
@@ -19,6 +19,7 @@ use Spatie\Ray\Payloads\CustomPayload;
 use Spatie\Ray\Payloads\DecodedJsonPayload;
 use Spatie\Ray\Payloads\FileContentsPayload;
 use Spatie\Ray\Payloads\HidePayload;
+use Spatie\Ray\Payloads\ImagePayload;
 use Spatie\Ray\Payloads\JsonStringPayload;
 use Spatie\Ray\Payloads\LogPayload;
 use Spatie\Ray\Payloads\MeasurePayload;

--- a/src/Ray.php
+++ b/src/Ray.php
@@ -254,6 +254,13 @@ class Ray
         return $this->sendRequest($payload);
     }
 
+    public function image(string $location): self
+    {
+        $payload = new ImagePayload($location);
+
+        return $this->sendRequest($payload);
+    }
+
     public function die($status = '')
     {
         die($status);

--- a/tests/RayTest.php
+++ b/tests/RayTest.php
@@ -505,6 +505,14 @@ class RayTest extends TestCase
         $this->assertEquals($ray->settings, SettingsFactory::createFromConfigFile());
     }
 
+    /** @test */
+    public function it_sends_an_image_payload()
+    {
+        $this->ray->image('http://localhost/test.jpg');
+
+        $this->assertMatchesOsSafeSnapshot($this->client->sentPayloads());
+    }
+
     protected function getValueOfLastSentContent(string $contentKey)
     {
         $payload = $this->client->sentPayloads();

--- a/tests/__snapshots__/RayTest__it_sends_an_image_payload__1.json
+++ b/tests/__snapshots__/RayTest__it_sends_an_image_payload__1.json
@@ -1,0 +1,19 @@
+[
+    {
+        "uuid": "fakeUuid",
+        "payloads": [
+            {
+                "type": "custom",
+                "content": {
+                    "content": "<img src=\"http:\/\/localhost\/test.jpg\" alt=\"\" \/>",
+                    "label": "Image"
+                },
+                "origin": {
+                    "file": "\/tests\/RayTest.php",
+                    "line_number": "xxx"
+                }
+            }
+        ],
+        "meta": []
+    }
+]


### PR DESCRIPTION
This PR adds an `image()` method that allows the user to display an image url or local file in Ray.  It was created in response to [this discussion](https://github.com/spatie/laravel-ray/discussions/101).  I believe this could be quite useful, especially for developers generating images or image URLs dynamically.

Documentation and unit tests have been included.

![image](https://user-images.githubusercontent.com/5508707/104717133-dc209b00-56f6-11eb-85ed-b318c984d96f.png)

