### PR TITLE
Add version specification

### DIFF
--- a/docs/environment-specific-configuration/docker.md
+++ b/docs/environment-specific-configuration/docker.md
@@ -32,7 +32,7 @@ return [
 ```
 
 
-On Linux, you will need to add an 'extra_hosts' parameter to your container definitions to expose 'host.docker.internal'.
+On Linux, you will need to add an 'extra_hosts' parameter to your container definitions to expose 'host.docker.internal'. Please make sure you are using Docker `20.03` or higher.
 ```
 #docker-compose.yml
 


### PR DESCRIPTION
According to this article: https://megamorf.gitlab.io/2020/09/19/access-native-services-on-docker-host-via-host-docker-internal/

The `host-gateway` option is available since Docker `20.03`.

Change is based on this issue: https://github.com/spatie/laravel-ray/issues/102