### PR TITLE
Automatically use specialised payload

### DIFF
--- a/docs/usage/framework-agnostic-php-project.md
+++ b/docs/usage/framework-agnostic-php-project.md
@@ -386,3 +386,15 @@ Alternatively, you can use the `rd` function.
 ```php
 rd($anything);
 ```
+
+### Showing raw values
+
+When you sent certain values to Ray, such as Carbon instances or Eloquent models, these values will be displayed in nice way. To see all private, protected, and public properties of such values, you can use the `raw()` method.
+
+```php
+$eloquentModel = User::create(['email' => 'john@example.com']);
+
+ray(new Carbon, $eloquentModel)); // will be formatted nicely
+
+ray()->raw(new Carbon, $eloquentModel) // no custom formatting, all properties will be shown in Ray.
+```

--- a/docs/usage/framework-agnostic-php-project.md
+++ b/docs/usage/framework-agnostic-php-project.md
@@ -112,6 +112,8 @@ ray()->pause();
 If you press the "Continue" button in Ray, execution will continue. When you press "Stop execution", Ray will throw an
 exception in your app to halt execution.
 
+If you are using Windows, you must set the maximum execution time to a high value, as the paused time will count against the maximum execution time.
+
 ### Counting execution times
 
 You can display a count of how many times a piece of code was called using `count`.

--- a/docs/using-a-config-file/framework-agnostic-php.md
+++ b/docs/using-a-config-file/framework-agnostic-php.md
@@ -28,5 +28,10 @@ return [
      *  Absolute base path for your sites or projects on your local computer where your IDE or code editor is running on. 
      */
     'local_path' => null,
+    
+    /*
+     * When this setting is enabled, the package will not try to format values sent to Ray.
+     */
+    'always_send_raw_values' => false,
 ];
 ```

--- a/docs/using-a-config-file/laravel.md
+++ b/docs/using-a-config-file/laravel.md
@@ -51,5 +51,10 @@ return [
      * computer where your IDE or code editor is running on.
      */
     'local_path' => env('RAY_LOCAL_PATH', null),
+    
+    /*
+     * When this setting is enabled, the package will not try to format values sent to Ray.
+     */
+    'always_send_raw_values' => false,
 ];
 ```

--- a/docs/using-a-config-file/wordpress.md
+++ b/docs/using-a-config-file/wordpress.md
@@ -28,5 +28,10 @@ return [
      *  Absolute base path for your sites or projects on your local computer where your IDE or code editor is running on. 
      */
     'local_path' => null,
+    
+    /*
+     * When this setting is enabled, the package will not try to format values sent to Ray.
+     */
+    'always_send_raw_values' => false,
 ];
 ```

--- a/docs/using-a-config-file/yii2.md
+++ b/docs/using-a-config-file/yii2.md
@@ -38,6 +38,11 @@ return [
      * computer where your IDE or code editor is running on.
      */
     'local_path' => null,
+    
+    /*
+     * When this setting is enabled, the package will not try to format values sent to Ray.
+     */
+    'always_send_raw_values' => false,
 ];
 
 ```

--- a/src/PayloadFactory.php
+++ b/src/PayloadFactory.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Spatie\Ray;
+
+use Carbon\Carbon;
+use Spatie\Ray\Payloads\CarbonPayload;
+use Spatie\Ray\Payloads\LogPayload;
+use Spatie\Ray\Payloads\Payload;
+
+class PayloadFactory
+{
+    protected array $values;
+
+    public static function createForValues(array $arguments): array
+    {
+        return (new static($arguments))->getPayloads();
+    }
+
+    public function __construct(array $values)
+    {
+        $this->values = $values;
+    }
+
+    public function getPayloads(): array
+    {
+        return array_map(function($value) {
+            return $this->getPayload($value);
+
+        }, $this->values);
+    }
+
+    protected function getPayload($value): Payload
+    {
+        if ($value instanceof Carbon) {
+            return new CarbonPayload($value);
+        }
+
+        $primitiveValue = ArgumentConverter::convertToPrimitive($value);
+
+        return new LogPayload($primitiveValue);
+    }
+}

--- a/src/PayloadFactory.php
+++ b/src/PayloadFactory.php
@@ -3,6 +3,7 @@
 namespace Spatie\Ray;
 
 use Carbon\Carbon;
+use Closure;
 use Spatie\Ray\Payloads\CarbonPayload;
 use Spatie\Ray\Payloads\LogPayload;
 use Spatie\Ray\Payloads\Payload;
@@ -11,9 +12,16 @@ class PayloadFactory
 {
     protected array $values;
 
+    protected static ?Closure $payloadFinder;
+
     public static function createForValues(array $arguments): array
     {
         return (new static($arguments))->getPayloads();
+    }
+
+    public static function registerPayloadFinder(callable $callable)
+    {
+        self::$payloadFinder = $callable;
     }
 
     public function __construct(array $values)
@@ -30,6 +38,12 @@ class PayloadFactory
 
     protected function getPayload($value): Payload
     {
+        if (self::$payloadFinder) {
+            if ($payload = (static::$payloadFinder)($value)) {
+                return $payload;
+            }
+        }
+
         if ($value instanceof Carbon) {
             return new CarbonPayload($value);
         }

--- a/src/PayloadFactory.php
+++ b/src/PayloadFactory.php
@@ -12,7 +12,7 @@ class PayloadFactory
 {
     protected array $values;
 
-    protected static ?Closure $payloadFinder;
+    protected static ?Closure $payloadFinder = null;
 
     public static function createForValues(array $arguments): array
     {

--- a/src/Ray.php
+++ b/src/Ray.php
@@ -24,6 +24,7 @@ use Spatie\Ray\Payloads\FileContentsPayload;
 use Spatie\Ray\Payloads\HidePayload;
 use Spatie\Ray\Payloads\ImagePayload;
 use Spatie\Ray\Payloads\JsonStringPayload;
+use Spatie\Ray\Payloads\LogPayload;
 use Spatie\Ray\Payloads\MeasurePayload;
 use Spatie\Ray\Payloads\NewScreenPayload;
 use Spatie\Ray\Payloads\NotifyPayload;
@@ -369,6 +370,19 @@ class Ray
         do {
             sleep(1);
         } while (self::$client->lockExists($lockName));
+
+        return $this;
+    }
+
+    public function raw(...$arguments): self
+    {
+        if (! count($arguments)) {
+            return $this;
+        }
+
+        $payload = new LogPayload($arguments);
+
+        $this->sendRequest($payload);
 
         return $this;
     }

--- a/src/Ray.php
+++ b/src/Ray.php
@@ -380,9 +380,9 @@ class Ray
             return $this;
         }
 
-        $payload = LogPayload::createForArguments($arguments);
+        $payloads = PayloadFactory::createForValues($arguments);
 
-        return $this->sendRequest($payload);
+        return $this->sendRequest($payloads);
     }
 
     public function pass($argument)

--- a/src/Ray.php
+++ b/src/Ray.php
@@ -136,7 +136,7 @@ class Ray
             return $this->measureClosure($stopwatchName);
         }
 
-        if (! isset(static::$stopWatches[$stopwatchName])) {
+        if (!isset(static::$stopWatches[$stopwatchName])) {
             $stopwatch = new Stopwatch(true);
             static::$stopWatches[$stopwatchName] = $stopwatch;
 
@@ -278,7 +278,7 @@ class Ray
             $boolOrCallable = (bool)$boolOrCallable();
         }
 
-        if (! $boolOrCallable) {
+        if (!$boolOrCallable) {
             $this->remove();
         }
 
@@ -376,20 +376,22 @@ class Ray
 
     public function raw(...$arguments): self
     {
-        if (! count($arguments)) {
+        if (!count($arguments)) {
             return $this;
         }
 
-        $payload = new LogPayload($arguments);
+        $payloads = array_map(function ($argument) {
+            return LogPayload::createForArguments([$argument]);
+        }, $arguments);
 
-        $this->sendRequest($payload);
+        $this->sendRequest($payloads);
 
         return $this;
     }
 
     public function send(...$arguments): self
     {
-        if (! count($arguments)) {
+        if (!count($arguments)) {
             return $this;
         }
 
@@ -413,7 +415,7 @@ class Ray
     }
 
     /**
-     * @param \Spatie\Ray\Payloads\Payload|\Spatie\Ray\Payloads\Payload[]$payloads
+     * @param \Spatie\Ray\Payloads\Payload|\Spatie\Ray\Payloads\Payload[] $payloads
      * @param array $meta
      *
      * @return $this
@@ -421,7 +423,7 @@ class Ray
      */
     public function sendRequest($payloads, array $meta = []): self
     {
-        if (! is_array($payloads)) {
+        if (!is_array($payloads)) {
             $payloads = [$payloads];
         }
 

--- a/src/Ray.php
+++ b/src/Ray.php
@@ -384,15 +384,17 @@ class Ray
             return LogPayload::createForArguments([$argument]);
         }, $arguments);
 
-        $this->sendRequest($payloads);
-
-        return $this;
+        return $this->sendRequest($payloads);
     }
 
     public function send(...$arguments): self
     {
         if (!count($arguments)) {
             return $this;
+        }
+
+        if ($this->settings->always_send_raw_values) {
+            return $this->raw(...$arguments);
         }
 
         $payloads = PayloadFactory::createForValues($arguments);

--- a/src/Settings/Settings.php
+++ b/src/Settings/Settings.php
@@ -11,6 +11,7 @@ class Settings
         'port' => 23517,
         'remote_path' => null,
         'local_path' => null,
+        'always_send_raw_values' => false,
     ];
 
     public function __construct(array $settings)

--- a/tests/RayTest.php
+++ b/tests/RayTest.php
@@ -540,6 +540,16 @@ class RayTest extends TestCase
         $this->assertEquals('UTC', $payload['payloads'][0]['content']['timezone']);
     }
 
+    /** @test */
+    public function it_can_send_the_raw_values()
+    {
+        TestTime::freeze('Y-m-d H:i:s', '2020-01-01 00:00:00');
+
+        $this->ray->raw(new Carbon, 'string', ['a' => 1]);
+
+        $this->assertMatchesOsSafeSnapshot($this->client->sentPayloads());
+    }
+
     protected function getValueOfLastSentContent(string $contentKey)
     {
         $payload = $this->client->sentPayloads();

--- a/tests/RayTest.php
+++ b/tests/RayTest.php
@@ -543,11 +543,26 @@ class RayTest extends TestCase
     /** @test */
     public function it_can_send_the_raw_values()
     {
-        TestTime::freeze('Y-m-d H:i:s', '2020-01-01 00:00:00');
+        $this->ray->raw(new Carbon(), 'string', ['a' => 1]);
 
-        $this->ray->raw(new Carbon, 'string', ['a' => 1]);
+        $payloads = $this->client->sentPayloads();
 
-        $this->assertMatchesOsSafeSnapshot($this->client->sentPayloads());
+        $this->assertEquals('log', $payloads[0]['payloads'][0]['type']);
+        $this->assertEquals('log', $payloads[0]['payloads'][1]['type']);
+        $this->assertEquals('log', $payloads[0]['payloads'][2]['type']);
+    }
+
+    /** @test */
+    public function it_will_automatically_use_a_specialized_payloads()
+    {
+        $this->ray->send(new Carbon(), 'string', ['a => 1']);
+
+        $payloads = $this->client->sentPayloads();
+
+        $this->assertEquals('carbon', $payloads[0]['payloads'][0]['type']);
+        $this->assertEquals('log', $payloads[0]['payloads'][1]['type']);
+        $this->assertEquals('log', $payloads[0]['payloads'][2]['type']);
+
     }
 
     protected function getValueOfLastSentContent(string $contentKey)

--- a/tests/SettingsTest.php
+++ b/tests/SettingsTest.php
@@ -21,25 +21,23 @@ class SettingsTest extends TestCase
     public function it_can_find_the_settings_file()
     {
         $this->skipOnGitHubActions();
-        ;
 
         $settings = SettingsFactory::createFromConfigFile(__DIR__ . Ray::makePathOsSafe('/testSettings/subDirectory/subSubDirectory'));
 
         $this->assertEquals(12345, $settings->port);
         $this->assertEquals('http://otherhost', $settings->host);
     }
-    
+
     /** @test */
     public function it_can_find_the_settings_file_more_than_once()
     {
         $this->skipOnGitHubActions();
-        ;
 
         $settings1 = SettingsFactory::createFromConfigFile(__DIR__ . Ray::makePathOsSafe('/testSettings/subDirectory/subSubDirectory'));
 
         $this->assertEquals(12345, $settings1->port);
         $this->assertEquals('http://otherhost', $settings1->host);
-        
+
         $settings2 = SettingsFactory::createFromConfigFile(__DIR__ . Ray::makePathOsSafe('/testSettings/subDirectory/subSubDirectory'));
 
         $this->assertEquals(12345, $settings2->port);

--- a/tests/__snapshots__/RayTest__it_can_send_a_color_and_a_size__1.json
+++ b/tests/__snapshots__/RayTest__it_can_send_a_color_and_a_size__1.json
@@ -6,7 +6,18 @@
                 "type": "log",
                 "content": {
                     "values": [
-                        "test",
+                        "test"
+                    ]
+                },
+                "origin": {
+                    "file": "\/tests\/RayTest.php",
+                    "line_number": "xxx"
+                }
+            },
+            {
+                "type": "log",
+                "content": {
+                    "values": [
                         "test2"
                     ]
                 },

--- a/tests/__snapshots__/RayTest__it_can_send_multiple_things_in_one_go_to_ray__1.json
+++ b/tests/__snapshots__/RayTest__it_can_send_multiple_things_in_one_go_to_ray__1.json
@@ -6,8 +6,30 @@
                 "type": "log",
                 "content": {
                     "values": [
-                        "first",
-                        "second",
+                        "first"
+                    ]
+                },
+                "origin": {
+                    "file": "\/tests\/RayTest.php",
+                    "line_number": "xxx"
+                }
+            },
+            {
+                "type": "log",
+                "content": {
+                    "values": [
+                        "second"
+                    ]
+                },
+                "origin": {
+                    "file": "\/tests\/RayTest.php",
+                    "line_number": "xxx"
+                }
+            },
+            {
+                "type": "log",
+                "content": {
+                    "values": [
                         "third"
                     ]
                 },


### PR DESCRIPTION
This PR will let 

```php
ray(new Carbon);
```

send the same payload as 

```php
ray()->carbon(new Carbon);
```