### PR TITLE
Fix spelling mistakes in bug report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -8,9 +8,9 @@ assignees: ''
 ---
 
 **Before creating a new bug report**
-Please check if there isn't a similar issue on [the issue tracker](https://github.com/spatie/ray/issues) or in [the discusstions](https://github.com/spatie/ray/issues).
+Please check if there isn't a similar issue on [the issue tracker](https://github.com/spatie/ray/issues) or in [the discussions](https://github.com/spatie/ray/issues).
 
-If you are having troubles connecting your project to Ray, please check [our docs](https://spatie.be/products/ray) first, espcially the configuration and environment specific configuration sections.
+If you are having troubles connecting your project to Ray, please check [our docs](https://spatie.be/products/ray) first, especially the configuration and environment specific configuration sections.
 
 **Describe the bug**
 A clear and concise description of what the bug is.


### PR DESCRIPTION
I couldn't help but notice the mistakes when creating the bug report so I thought: why not fix them :)