### PR TITLE
Refer to the Docker specific documentation

### DIFF
--- a/docs/using-a-config-file/laravel.md
+++ b/docs/using-a-config-file/laravel.md
@@ -3,7 +3,9 @@ title: Laravel
 weight: 3
 ---
 
-For Laravel projects you can create a `ray.php` file in your project directory (not in the `config` directory) using the following template as [the ray config file](/docs/ray/v1/configuration/general):
+For Laravel projects you can create a `ray.php` file in your project directory (not in the `config` directory) using the following template as [the ray config file](/docs/ray/v1/configuration/general). Since the configuration file is developer specific, you might want to add it to the `.gitignore` of the project.
+
+Note: if everyone working on the project needs the same configuration, you can put the file in the `config` directory as well.
 
 ```php
 // save this in a file called "ray.php" in the root directory of your project; not in the Laravel "config" directory
@@ -53,3 +55,6 @@ return [
     'local_path' => env('RAY_LOCAL_PATH', null),
 ];
 ```
+
+## Docker
+See [our Docker-specific configuration page](/docs/ray/v1/environment-specific-configuration/docker) for information about setting up Ray in combination with Docker. All changes also apply to a setup with Laravel.


### PR DESCRIPTION
Add a link to our Docker specific documentation on the Laravel specific page. This makes it clear that more specific setup is needed in order to get Docker worker with Ray when using Laravel.

Also prefer placement of the `ray.php` configuration file in the `config/` directory instead of in the root of the project. Both seem to work just fine but I think that it is better to stick with Laravel standards when writing documentation, unless there are good reasons not to.