### PR TITLE
Fix whitespace in framework agnostic docs

### DIFF
--- a/docs/installation-in-your-project/framework-agnostic-php.md
+++ b/docs/installation-in-your-project/framework-agnostic-php.md
@@ -3,7 +3,7 @@ title: Framework agnostic PHP
 weight: 2
 ---
 
-To start using Ray any PHP project , install the `ray` package.
+To start using Ray in any PHP project, install the `ray` package.
 
 ```bash
 composer require spatie/ray


### PR DESCRIPTION
I also added an `in` to the first sentence since it seemed like that was missing.