### PR TITLE
linux-specific configuration docs

### DIFF
--- a/docs/environment-specific-configuration/linux.md
+++ b/docs/environment-specific-configuration/linux.md
@@ -1,0 +1,25 @@
+---
+
+title: Linux
+weight: 3
+
+---
+
+When using the Linux AppImage, the automatic updates rename the binary with the latest version _(i.e., Ray-1.12.0.AppImage)_.
+
+Instead of symlinking the binary directly, you can use the following script to always run the latest version of Ray by placing it in the same directory as the Ray binary:
+
+
+
+__ray-latest.sh__
+
+```bash
+#!/bin/bash
+
+THIS_DIR=$(realpath `dirname $0`)
+LATEST_BINARY=$(ls -1 $THIS_DIR/Ray-*.*.AppImage | sort -r | head -n 1)
+
+$LATEST_BINARY
+```
+
+


### PR DESCRIPTION
This PR adds linux-specific configuration documentation. Specifically, it contains a basic bash script to launch the latest version of the Ray binary. 

This is necessary because the linux AppImage binary is renamed whenever Ray auto-updates.  For example:
`/usr/bin/Ray-1.11.0.AppImage` updates and becomes `/usr/bin/Ray-1.12.0.AppImage`.  This means that it's not possible to directly symlink the binary in the user menus.  The script contained in these docs/PR resolves this issue.