### PR TITLE
Cache config file location

### DIFF
--- a/src/Settings/SettingsFactory.php
+++ b/src/Settings/SettingsFactory.php
@@ -4,6 +4,8 @@ namespace Spatie\Ray\Settings;
 
 class SettingsFactory
 {
+    public static $cache = [];
+
     public static function createFromConfigFile(string $configDirectory = null): Settings
     {
         $settingValues = (new static())->getSettingsFromConfigFile($configDirectory);
@@ -13,7 +15,7 @@ class SettingsFactory
 
     public function getSettingsFromConfigFile(string $configDirectory = null): array
     {
-        $configFilePath = $this->searchConfigFiles($configDirectory);
+        $configFilePath = $this->searchCachedConfigFiles($configDirectory);
 
         if (! file_exists($configFilePath)) {
             return [];
@@ -53,5 +55,14 @@ class SettingsFactory
         }
 
         return '';
+    }
+
+    protected function searchCachedConfigFiles(string $configDirectory = null): string
+    {
+        if (! isset(self::$cache[$configDirectory])) {
+            self::$cache[$configDirectory] = $this->searchConfigFiles($configDirectory);
+        }
+
+        return self::$cache[$configDirectory];
     }
 }


### PR DESCRIPTION
This PR adds a caching mechanism to the `SettingsFactory::getSettingsFromConfigFile()` method, reducing disk reads significantly.

Original behavior: Every time `ray()` is called, a new search is performed to locate a `ray.php` configuration file.
New behavior: Search results are cached based on the specified `$configDirectory`, reducing the overall number of searches.