### PR TITLE
Use http v1.1 instead of 1.0

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -100,7 +100,7 @@ class Client
         curl_setopt($curlHandle, CURLOPT_RETURNTRANSFER, true);
         curl_setopt($curlHandle, CURLOPT_TIMEOUT, 2);
         curl_setopt($curlHandle, CURLOPT_SSL_VERIFYPEER, true);
-        curl_setopt($curlHandle, CURLOPT_HTTP_VERSION, CURL_HTTP_VERSION_1_0);
+        curl_setopt($curlHandle, CURLOPT_HTTP_VERSION, CURL_HTTP_VERSION_1_1);
         curl_setopt($curlHandle, CURLOPT_ENCODING, '');
         curl_setopt($curlHandle, CURLINFO_HEADER_OUT, true);
         curl_setopt($curlHandle, CURLOPT_FAILONERROR, true);


### PR DESCRIPTION
This PR changes the HTTP version used by cURL _(the `Client` class)_ to 1.1 instead of 1.0.

Using HTTP/1.1 allows more efficient connections to the Ray Express server _(connections are kept open - http/1.1 - instead of opening a new connection for each request - http/1.0)_.

According to [RFC 2616 8.x](https://www.w3.org/Protocols/rfc2616/rfc2616-sec8.html), some benefits of using HTTP/1.1 are:
- `By opening and closing fewer TCP connections, CPU time is saved...`
- `Network congestion is reduced...`
- `Latency on subsequent requests is reduced ...`

Developers may see increased performance when using a large number of `ray()` calls, and _may_ also result in lower memory/CPU usage by the Ray app, depending on how many calls to `ray()` exist.

The Ray app's _(v1.12.0)_ Express server sends the following headers, indicating that HTTP 1.1 and persistent connections can be used:

```http
HTTP/1.1 200 OK
X-Powered-By: Express
...
Connection: keep-alive
```