### PR TITLE
Fix: remote_path/local_path replacements

### DIFF
--- a/src/Payloads/Payload.php
+++ b/src/Payloads/Payload.php
@@ -24,7 +24,9 @@ abstract class Payload
             return $filePath;
         }
 
-        return substr_replace($filePath, $this->localPath, 0, strlen($this->remotePath));
+        $pattern = '~^' . preg_quote($this->remotePath, '~') . '~';
+
+        return preg_replace($pattern, $this->localPath, $filePath);
     }
 
     public function getContent(): array

--- a/tests/RayTest.php
+++ b/tests/RayTest.php
@@ -6,6 +6,7 @@ use Carbon\Carbon;
 use Illuminate\Support\Arr;
 use PHPUnit\Framework\TestCase;
 use Spatie\Backtrace\Frame;
+use Spatie\Ray\Payloads\BoolPayload;
 use Spatie\Ray\Payloads\CallerPayload;
 use Spatie\Ray\Payloads\LogPayload;
 use Spatie\Ray\Ray;
@@ -474,6 +475,25 @@ class RayTest extends TestCase
         $payload->localPath = '/some/local/path';
 
         $this->assertEquals('/some/local/path/app/MyFile.php', $payload->getContent()['frame']['file_name']);
+    }
+
+    /** @test */
+    public function it_only_rewrites_paths_for_matching_remote_paths()
+    {
+        $payload = new CallerPayload([
+            new Frame('/app/files/MyFile.php', 1, []),
+            new Frame('/app/files/MyFile.php', 2, []),
+        ]);
+
+        $payload->remotePath = '/files';
+        $payload->localPath = '/some/local/path';
+
+        $this->assertEquals('/app/files/MyFile.php', $payload->getContent()['frame']['file_name']);
+
+        $payload->remotePath = '/app';
+        $payload->localPath = '/some/local/path';
+
+        $this->assertEquals('/some/local/path/files/MyFile.php', $payload->getContent()['frame']['file_name']);
     }
 
     /** @test */

--- a/tests/RayTest.php
+++ b/tests/RayTest.php
@@ -6,7 +6,6 @@ use Carbon\Carbon;
 use Illuminate\Support\Arr;
 use PHPUnit\Framework\TestCase;
 use Spatie\Backtrace\Frame;
-use Spatie\Ray\Payloads\BoolPayload;
 use Spatie\Ray\Payloads\CallerPayload;
 use Spatie\Ray\Payloads\LogPayload;
 use Spatie\Ray\Ray;


### PR DESCRIPTION
This PR resolves an issue with the way `Payload::replaceRemotePathWithLocalPath()` replaces the `remote_path` value with the `local_path` value: the replacement was done based on the length of the `remote_path` value, regardless of whether or not it was in the specified file path.  As a result, incorrect file paths were sent to the Ray app in some instances.

It was unclear whether or not the length-based replacement was done for a specific reason, so I'm assuming it's a bug.  This updates the behavior to only perform the replacement if the specified file path starts with the `remote_path` value.

See spatie/laravel-ray#128.