### PR TITLE
Add enabled state

### DIFF
--- a/docs/configuration/framework-agnostic-php.md
+++ b/docs/configuration/framework-agnostic-php.md
@@ -10,6 +10,11 @@ In framework agnostic projects you can use this template as [the ray config file
 <?php
 return [
     /*
+    * This settings controls whether data should be sent to Ray.
+    */
+    'enable' => true,
+    
+    /*
      *  The host used to communicate with the Ray app.
      */
     'host' => 'localhost',

--- a/docs/usage/reference.md
+++ b/docs/usage/reference.md
@@ -35,6 +35,10 @@ To display something in Ray use the `ray()` function. It accepts everything: str
 | `ray()->clearAll()` | Clear current and all previous screens |
 | `ray()->count()` | Count how many times a piece of code is called |
 | `ray(…)->die()` or `rd(…)` | Stop the PHP process |
+| `ray()->disable()` | Disable sending stuff to Ray |
+| `ray()->disabled()` | Check if Ray is disabled |
+| `ray()->enable()` | Enable sending stuff to Ray |
+| `ray()->enabled()` | Check if Ray is enabled |
 | `ray()->file($path)` | Display contents of a file |
 | `ray(…)->gray()` | Output in gray |
 | `ray(…)->green()` | Output in green |

--- a/src/Ray.php
+++ b/src/Ray.php
@@ -84,9 +84,7 @@ class Ray
 
         $this->uuid = $uuid ?? static::$fakeUuid ?? Uuid::uuid4()->toString();
 
-        if ($this->settings->enable === false) {
-            $this->disable();
-        }
+        static::$enabled = $this->settings->enable !== false;
     }
 
     public function enable(): self

--- a/src/Ray.php
+++ b/src/Ray.php
@@ -84,7 +84,9 @@ class Ray
 
         $this->uuid = $uuid ?? static::$fakeUuid ?? Uuid::uuid4()->toString();
 
-        static::$enabled = $this->settings->enable ?? true;
+        if ($this->settings->enable === false) {
+            $this->disable();
+        }
     }
 
     public function enable(): self

--- a/src/Ray.php
+++ b/src/Ray.php
@@ -64,6 +64,9 @@ class Ray
     /** @var \Symfony\Component\Stopwatch\Stopwatch[] */
     public static $stopWatches = [];
 
+    /** @var bool */
+    public static $enabled = true;
+
     public static function create(Client $client = null, string $uuid = null): self
     {
         $settings = SettingsFactory::createFromConfigFile();
@@ -80,6 +83,32 @@ class Ray
         self::$counters = self::$counters ?? new Counters();
 
         $this->uuid = $uuid ?? static::$fakeUuid ?? Uuid::uuid4()->toString();
+
+        static::$enabled = $this->settings->enable ?? true;
+    }
+
+    public function enable(): self
+    {
+        static::$enabled = true;
+
+        return $this;
+    }
+
+    public function disable(): self
+    {
+        static::$enabled = false;
+
+        return $this;
+    }
+
+    public function enabled(): bool
+    {
+        return static::$enabled;
+    }
+
+    public function disabled(): bool
+    {
+        return ! static::$enabled;
     }
 
     public static function useClient(Client $client): void
@@ -485,6 +514,10 @@ class Ray
      */
     public function sendRequest($payloads, array $meta = []): self
     {
+        if (! $this->enabled()) {
+            return $this;
+        }
+
         if (! is_array($payloads)) {
             $payloads = [$payloads];
         }

--- a/src/Settings/Settings.php
+++ b/src/Settings/Settings.php
@@ -9,6 +9,7 @@ class Settings
 
     /** @var array */
     protected $defaultSettings = [
+        'enable' => true,
         'host' => 'localhost',
         'port' => 23517,
         'remote_path' => null,

--- a/tests/RayTest.php
+++ b/tests/RayTest.php
@@ -722,6 +722,40 @@ class RayTest extends TestCase
         $this->assertEquals('log',  $this->client->sentPayloads()[0]['payloads'][0]['type']);
     }
 
+    /** @test */
+    public function it_can_be_disabled()
+    {
+        $this->ray->send('test payload 1');
+        $this->ray->disable();
+        $this->ray->send('test payload 2');
+
+        $this->assertCount(1, $this->client->sentPayloads());
+    }
+
+    /** @test */
+    public function it_can_be_reenabled_after_being_disabled()
+    {
+        $this->ray->send('test payload 1');
+        $this->ray->disable();
+        $this->ray->send('test payload 2');
+        $this->ray->enable();
+        $this->ray->send('test payload 3');
+
+        $this->assertCount(2, $this->client->sentPayloads());
+    }
+
+    /** @test */
+    public function it_returns_the_correct_enabled_state()
+    {
+        Ray::$enabled = true;
+        $this->assertTrue($this->ray->enabled());
+        $this->assertFalse($this->ray->disabled());
+
+        Ray::$enabled = false;
+        $this->assertFalse($this->ray->enabled());
+        $this->assertTrue($this->ray->disabled());
+    }
+
     protected function getValueOfLastSentContent(string $contentKey)
     {
         $payload = $this->client->sentPayloads();

--- a/tests/RayTest.php
+++ b/tests/RayTest.php
@@ -757,6 +757,12 @@ class RayTest extends TestCase
         $this->assertTrue($this->ray->disabled());
     }
 
+    /** @test */
+    public function it_defaults_to_enabled_state()
+    {
+        $this->assertTrue($this->ray->enabled());
+    }
+
     protected function getValueOfLastSentContent(string $contentKey)
     {
         $payload = $this->client->sentPayloads();

--- a/tests/RayTest.php
+++ b/tests/RayTest.php
@@ -735,6 +735,7 @@ class RayTest extends TestCase
     /** @test */
     public function it_can_be_reenabled_after_being_disabled()
     {
+        $this->ray->enable();
         $this->ray->send('test payload 1');
         $this->ray->disable();
         $this->ray->send('test payload 2');


### PR DESCRIPTION
This PR adds the `enable()`, `enabled()`, `disable()`, `disabled()` methods and the `static $enabled` property to the `Ray` class - previously, these only existed in most of the other related packages _(`spatie/laravel-ray`, ...)_.

It will help add to a positive developer experience, allowing all developers to toggle the enabled state regardless of which package they're using.

If this PR is accepted, I will submit PRs for the other packages (`laravel-ray`, `wordpress-ray`, etc.) to remove the duplicate methods _(unless you'd like to leave them as-is)_.

**Note**: The package doesn't appear to have been published yet, but the current implementation of `Ray::$enabled` in `spatie/ray-bundle` WILL break as it's declared with a property type: https://github.com/spatie/ray-bundle/blob/master/src/Ray.php#L13. Converting the type to a `@var` phpdoc, as in the other packages, will resolve the issue.
