### PR TITLE
Send XML payloads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to `ray` will be documented in this file
 
+## 1.17.4 - 2021-02-03
+
+- fix: remote_path/local_path replacements (#269)
+
 ## 1.17.3 - 2021-02-02
 
 - use http v1.1 instead of 1.0 (#267)

--- a/docs/usage/framework-agnostic-php-project.md
+++ b/docs/usage/framework-agnostic-php-project.md
@@ -237,6 +237,18 @@ The `json` function can also accept multiple valid JSON strings.
 ray()->json($jsonString, $anotherJsonString, $yetAnotherJsonString);
 ```
 
+### Working with XML
+
+You can send a valid XML string to Ray with the `xml` function.
+
+It will be displayed as formatted XML and collapsable in Ray.
+
+```php
+$xmlString = '<one><two><three>3</three></two></one>';
+
+ray()->xml($xmlString);
+```
+
 ### Working with Carbon instances
 
 [Carbon](https://carbon.nesbot.com/docs/) is a popular datetime package. You can send instances of `Carbon` to Ray with `carbon`.

--- a/docs/usage/reference.md
+++ b/docs/usage/reference.md
@@ -62,6 +62,7 @@ To display something in Ray use the `ray()` function. It accepts everything: str
 | `ray()->table($array. $label)` | Format an associative array with optional label  |
 | `ray()->toJson($variable, $another, … )` | Display the JSON representation of 1 or more values that can be converted |
 | `ray()->trace()` | Check entire backtrace |
+| `ray()->xml($xmlString)` | Display formatted XML in Ray |
 
 ### Updating a Ray instance
 

--- a/src/Payloads/XmlPayload.php
+++ b/src/Payloads/XmlPayload.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Spatie\Ray\Payloads;
+
+class XmlPayload extends Payload
+{
+    /** @var string */
+    protected $value;
+
+    public function __construct(string $value)
+    {
+        $this->value = $value;
+    }
+
+    public function getType(): string
+    {
+        return 'custom';
+    }
+
+    public function getContent(): array
+    {
+        $content = $this->formatXmlForDisplay($this->value);
+
+        return [
+            'content' => $content,
+            'label' => 'XML',
+        ];
+    }
+
+    protected function formatXmlForDisplay(string $xml): string
+    {
+        $content = $this->formatAndIndentXml($xml);
+
+        return str_replace(
+            [PHP_EOL, ' '],
+            ['<br>', '&nbsp;'],
+            htmlspecialchars($content)
+        );
+    }
+
+    protected function formatAndIndentXml(string $xml): string
+    {
+        if (!class_exists(\DOMDocument::class)) {
+            return $xml;
+        }
+
+        $dom = new \DOMDocument;
+
+        $dom->preserveWhiteSpace = false;
+        $dom->strictErrorChecking = false;
+        $dom->formatOutput = true;
+
+        if (!$dom->loadXML($xml, LIBXML_NOERROR | LIBXML_NOWARNING)) {
+            return $xml;
+        }
+
+        return $dom->saveXML();
+    }
+}

--- a/src/Payloads/XmlPayload.php
+++ b/src/Payloads/XmlPayload.php
@@ -31,11 +31,14 @@ class XmlPayload extends Payload
     {
         $content = $this->formatAndIndentXml($xml);
 
-        return str_replace(
-            [PHP_EOL, ' '],
-            ['<br>', '&nbsp;'],
-            htmlspecialchars($content)
-        );
+        return $this->encodeXml(trim($content));
+    }
+
+    protected function encodeXml(string $xml): string
+    {
+        $result = htmlentities($xml);
+
+        return str_replace([PHP_EOL, "\n", ' '], ['<br>', '<br>', '&nbsp;'], $result);
     }
 
     protected function formatAndIndentXml(string $xml): string

--- a/src/Ray.php
+++ b/src/Ray.php
@@ -35,6 +35,7 @@ use Spatie\Ray\Payloads\ShowAppPayload;
 use Spatie\Ray\Payloads\SizePayload;
 use Spatie\Ray\Payloads\TablePayload;
 use Spatie\Ray\Payloads\TracePayload;
+use Spatie\Ray\Payloads\XmlPayload;
 use Spatie\Ray\Settings\Settings;
 use Spatie\Ray\Settings\SettingsFactory;
 use Spatie\Ray\Support\Counters;
@@ -416,6 +417,13 @@ class Ray
     public function html(string $html = ''): self
     {
         $payload = new HtmlPayload($html);
+
+        return $this->sendRequest($payload);
+    }
+
+    public function xml(string $xml): self
+    {
+        $payload = new XmlPayload($xml);
 
         return $this->sendRequest($payload);
     }

--- a/tests/RayTest.php
+++ b/tests/RayTest.php
@@ -628,6 +628,14 @@ class RayTest extends TestCase
     }
 
     /** @test */
+    public function it_sends_an_xml_payload()
+    {
+        $this->ray->xml('<root><one><two><three></three></two></one></root>');
+
+        $this->assertMatchesOsSafeSnapshot($this->client->sentPayloads());
+    }
+
+    /** @test */
     public function it_can_send_the_raw_values()
     {
         $this->ray->raw(new Carbon(), 'string', ['a' => 1]);

--- a/tests/RayTest.php
+++ b/tests/RayTest.php
@@ -630,7 +630,7 @@ class RayTest extends TestCase
     /** @test */
     public function it_sends_an_xml_payload()
     {
-        $this->ray->xml('<root><one><two><three></three></two></one></root>');
+        $this->ray->xml('<one><two>2</two></one>');
 
         $this->assertMatchesOsSafeSnapshot($this->client->sentPayloads());
     }

--- a/tests/__snapshots__/RayTest__it_sends_an_xml_payload__1.json
+++ b/tests/__snapshots__/RayTest__it_sends_an_xml_payload__1.json
@@ -1,0 +1,19 @@
+[
+    {
+        "uuid": "fakeUuid",
+        "payloads": [
+            {
+                "type": "custom",
+                "content": {
+                    "content": "&lt;?xml&nbsp;version=&quot;1.0&quot;?&gt;<br>&lt;root&gt;<br>&nbsp;&nbsp;&lt;one&gt;<br>&nbsp;&nbsp;&nbsp;&nbsp;&lt;two&gt;<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&lt;three\/&gt;<br>&nbsp;&nbsp;&nbsp;&nbsp;&lt;\/two&gt;<br>&nbsp;&nbsp;&lt;\/one&gt;<br>&lt;\/root&gt;<br>",
+                    "label": "XML"
+                },
+                "origin": {
+                    "file": "\/tests\/RayTest.php",
+                    "line_number": "xxx"
+                }
+            }
+        ],
+        "meta": []
+    }
+]

--- a/tests/__snapshots__/RayTest__it_sends_an_xml_payload__1.json
+++ b/tests/__snapshots__/RayTest__it_sends_an_xml_payload__1.json
@@ -5,7 +5,7 @@
             {
                 "type": "custom",
                 "content": {
-                    "content": "&lt;?xml&nbsp;version=&quot;1.0&quot;?&gt;<br>&lt;root&gt;<br>&nbsp;&nbsp;&lt;one&gt;<br>&nbsp;&nbsp;&nbsp;&nbsp;&lt;two&gt;<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&lt;three\/&gt;<br>&nbsp;&nbsp;&nbsp;&nbsp;&lt;\/two&gt;<br>&nbsp;&nbsp;&lt;\/one&gt;<br>&lt;\/root&gt;<br>",
+                    "content": "&lt;?xml&nbsp;version=&quot;1.0&quot;?&gt;<br>&lt;one&gt;<br>&nbsp;&nbsp;&lt;two&gt;2&lt;\/two&gt;<br>&lt;\/one&gt;",
                     "label": "XML"
                 },
                 "origin": {


### PR DESCRIPTION
This PR adds an `xml()` method to the `Ray` class.  It formats and sends the provided XML in the same way that formatted JSON can be sent to the Ray app.  Since `ray()` currently sends JSON and HTML (and markdown in `spatie/laravel-ray`, etc.), I feel that it's a worthwhile addition.

This was a feature request - see spatie/ray#253.