### PR TITLE
Update docs

### DIFF
--- a/docs/usage/framework-agnostic-php-project.md
+++ b/docs/usage/framework-agnostic-php-project.md
@@ -452,3 +452,33 @@ You can show and hide the Ray app via code.
 ray()->showApp(); // Ray will be brought to the foreground
 ray()->hideApp(); // Ray will be hidden
 ```
+
+### Enabling / disabling Ray
+
+You can enable and disable sending stuff to Ray with the `enable` and `disable` functions.
+
+```php
+ray('one'); // will be displayed in ray
+
+ray()->disable();
+
+ray('two'); // won't be displayed in ray
+
+ray()->enable();
+
+ray('three'); // will be displayed in ray
+```
+
+You can check if Ray is enabled or disabled with the `enabled` and `disabled` functions.
+
+```php
+ray()->disable();
+
+ray()->enabled(); // false
+ray()->disabled(); // true
+
+ray()->enable();
+
+ray()->enabled(); // true
+ray()->disabled(); // false
+```

--- a/docs/usage/laravel.md
+++ b/docs/usage/laravel.md
@@ -250,32 +250,3 @@ To display all requests made in your Laravel app in Ray, you can call `ray()->sh
 
 To enable this behaviour by default, you can set the `send_requests_to_ray` option in [the config file](https://spatie.be/docs/ray/v1/configuration/laravel) to `true`.
 
-### Enabling / disabling Ray
-
-You can enable and disable sending stuff to Ray with the `enable` and `disable` functions.
-
-```php
-ray('one'); // will be displayed in ray
-
-ray()->disable();
-
-ray('two'); // won't be displayed in ray
-
-ray()->enable();
-
-ray('three'); // will be displayed in ray
-```
-
-You can check if Ray is enabled or disabled with the `enabled` and `disabled` functions.
-
-```php
-ray()->disable();
-
-ray()->enabled(); // false
-ray()->disabled(); // true
-
-ray()->enable();
-
-ray()->enabled(); // true
-ray()->disabled(); // false
-```

--- a/docs/usage/reference.md
+++ b/docs/usage/reference.md
@@ -83,10 +83,6 @@ Read more on [Framework agnostic PHP](/docs/ray/v1/usage/framework-agnostic-php-
 
 | Call | Description |
 | --- | --- |
-| `ray()->disable()` | Disable sending stuff to Ray |
-| `ray()->disabled()` | Check if Ray is disabled |
-| `ray()->enable()` | Enable sending stuff to Ray |
-| `ray()->enabled()` | Check if Ray is enabled |
 | `ray()->mailable($mailable)` | Render a mailable  |
 | `ray()->markdown($markdown)` | Render markdown  |
 | `ray()->model($model)` | Display the attributes and relations of a model  |


### PR DESCRIPTION
This PR:
- moves the docs for `enable()`, etc. from Laravel usage to framework-agnostic usage
- updates the usage reference to reflect removal of `enabled` methods from `spatie/laravel-ray`