### PR TITLE
Update wordpress docs

### DIFF
--- a/docs/configuration/wordpress.md
+++ b/docs/configuration/wordpress.md
@@ -10,6 +10,11 @@ In WordPress apps you can use this template as [the ray config file](/docs/ray/v
 <?php
 return [
     /*
+    * This settings controls whether data should be sent to Ray.
+    */
+    'enable' => true,
+    
+    /*
      *  The host used to communicate with the Ray app.
      */
     'host' => 'localhost',

--- a/docs/usage/reference.md
+++ b/docs/usage/reference.md
@@ -122,8 +122,6 @@ Read more on [Laravel](/docs/ray/v1/usage/laravel)
 | `ray()->stopShowingQueries()` | Stop displaying queries  |
 | `ray()->showMails()` | Display all mails that are sent  |
 | `ray()->stopShowingMails()` | Stop displaying mails  |
-| `ray()->disable()` | Disable sending stuff to Ray |
-| `ray()->enable()` | Enable sending stuff to Ray |
 
 Read more on [WordPress](/docs/ray/v1/usage/wordpress)
 

--- a/docs/usage/wordpress.md
+++ b/docs/usage/wordpress.md
@@ -3,7 +3,7 @@ title: WordPress
 weight: 4
 ---
 
-In WordPress, you can use all methods from [the framework agnostic version](/docs/ray/v1/usage/in-a-framework-agnostic-project).
+In WordPress, you can use all methods from [the framework agnostic version](/docs/ray/v1/usage/framework-agnostic-php-project).
 
 Additionally, you can use these following WordPress specific methods.
 
@@ -38,20 +38,10 @@ wp_mail('to@email.com', 'my subject', 'the content');
 
 To stop showing mail, call `stopShowingMails()`.
 
-### Enabling / disabling Ray
-
-You can enable and disable sending stuff to Ray with the `enable` and `disable` functions.
-
-```php
-ray('one') // will be displayed in ray
-
-ray()->disable();
-
-ray('two') // won't be displayed in ray
-
-ray()->enable();
-
-ray('three') // will be displayed in ray
-```
+### Production environments
 
 By default, Ray is disabled in production environments. If you want to use Ray in a production environment, you must explicitly enable it with `ray()->enable()`.
+
+For more information about using the `enable()` function, see the [framework agnostic docs](/docs/ray/v1/usage/framework-agnostic-php-project).
+
+


### PR DESCRIPTION
This PR updates the wordpress docs to reflect the removal of the `enable()` and `disable()` methods, as they have been moved to the `spatie/ray` package, and updates the suggested configuration to include the `enable` setting.  

It also fixes a broken link to the framework-agnostic docs in `usage/wordpress.md`.

These updates are related to PR spatie/wordpress-ray#32.