### PR TITLE
Update Yii docs

### DIFF
--- a/docs/usage/reference.md
+++ b/docs/usage/reference.md
@@ -129,10 +129,6 @@ Read more on [WordPress](/docs/ray/v1/usage/wordpress)
 
 | Call | Description |
 | --- | --- |
-| `ray()->disable()` | Disable sending stuff to Ray |
-| `ray()->disabled()` | Check if Ray is disabled |
-| `ray()->enable()` | Enable sending stuff to Ray |
-| `ray()->enabled()` | Check if Ray is enabled |
 | `ray()->showEvents()` | Display all events that are executed  |
 | `ray()->showEvents(callable)` | Display all events that are executed within a callable |
 | `ray()->stopShowingEvents()` | Stop displaying events  |
@@ -146,10 +142,6 @@ Read more on [Yii](/docs/ray/v1/usage/yii)
 
 | Call | Description |
 | --- | --- |
-| `ray()->disable()` | Disable sending stuff to Ray |
-| `ray()->disabled()` | Check if Ray is disabled |
-| `ray()->enable()` | Enable sending stuff to Ray |
-| `ray()->enabled()` | Check if Ray is enabled |
 | `ray()->showEvents()` | Display all events that are executed  |
 | `ray()->showEvents(callable)` | Display all events that are executed within a callable |
 | `ray()->stopShowingEvents()` | Stop displaying events  |

--- a/docs/usage/yii2.md
+++ b/docs/usage/yii2.md
@@ -79,32 +79,3 @@ ray()->showEvents(function() {
 Yii::$app->trigger('myEvent', new MyEvent()); // this event won't be displayed.
 ```
 
-### Enabling / disabling Ray
-
-You can enable and disable sending stuff to Ray with the `enable` and `disable` functions.
-
-```php
-ray('one') // will be displayed in ray
-
-ray()->disable();
-
-ray('two') // won't be displayed in ray
-
-ray()->enable();
-
-ray('three') // will be displayed in ray
-```
-
-You can check if Ray is enabled or disabled with the `enabled` and `disabled` functions.
-
-```php
-ray()->disable();
-
-ray()->enabled(); // false
-ray()->disabled(); // true
-
-ray()->enable();
-
-ray()->enabled(); // true
-ray()->disabled(); // false
-```


### PR DESCRIPTION
This PR updates the Yii & Craft docs to remove the `enabled()` and related methods as they have been moved to the base `spatie/ray` package.

The methods were removed by [this commit](https://github.com/spatie/yii-ray/commit/1a1b6ab72b4a2706564d70147fd86afca0649af6) in `spatie/yii-ray`.