### PR TITLE
Update Laravel docs

### DIFF
--- a/docs/usage/laravel.md
+++ b/docs/usage/laravel.md
@@ -250,3 +250,13 @@ To display all requests made in your Laravel app in Ray, you can call `ray()->sh
 
 To enable this behaviour by default, you can set the `send_requests_to_ray` option in [the config file](https://spatie.be/docs/ray/v1/configuration/laravel) to `true`.
 
+## Displaying Exceptions
+
+To display the details of an exception, you can call the `exception()` function:
+
+```php
+    $exception = new \Exception('test error');
+
+    ray()->exception($exception);
+```
+

--- a/docs/usage/reference.md
+++ b/docs/usage/reference.md
@@ -84,6 +84,7 @@ Read more on [Framework agnostic PHP](/docs/ray/v1/usage/framework-agnostic-php-
 
 | Call | Description |
 | --- | --- |
+| `ray()->exception($exception)` | Display the details of an exception  |
 | `ray()->mailable($mailable)` | Render a mailable  |
 | `ray()->markdown($markdown)` | Render markdown  |
 | `ray()->model($model)` | Display the attributes and relations of a model  |


### PR DESCRIPTION
This PR updates the Laravel docs with a description, an example, and reference for the `exception()` method added to `spatie/laravel-ray` package.  

Related PR: spatie/laravel-ray#141.