### PR TITLE
Add NodeJS docs

### DIFF
--- a/docs/configuration/nodejs.md
+++ b/docs/configuration/nodejs.md
@@ -1,0 +1,28 @@
+---
+title: NodeJS
+weight: 8
+---
+
+In NodeJS based projects, you can optionally create a `ray.config.js` file in your project directory. It's recommended to put `ray.config.js` in your `.gitignore` so your fellow developers can use their own configuration.
+
+You can use this template as [the ray config file](/docs/ray/v1/configuration/nodejs):
+
+```js
+// save this in a file named "ray.config.js"
+module.exports = {
+    /*
+    * This settings controls whether data should be sent to Ray.
+    */
+    enable: true,
+
+    /*
+     *  The host used to communicate with the Ray app.
+     */
+    host: 'localhost',
+
+    /*
+     *  The port number used to communicate with the Ray app. 
+     */
+    port: 23517,
+}
+```

--- a/docs/installation-in-your-project/nodejs.md
+++ b/docs/installation-in-your-project/nodejs.md
@@ -1,0 +1,8 @@
+---
+title: NodeJS
+weight: 7
+---
+
+You can send information from NodeJS code (JavaScript or TypeScript) to Ray via this third party package:
+
+[permafrost-dev/node-ray](https://github.com/permafrost-dev/node-ray)

--- a/docs/usage/nodejs.md
+++ b/docs/usage/nodejs.md
@@ -1,0 +1,221 @@
+---
+title: NodeJS
+weight: 7
+---
+
+The API for the NodeJS package closely mirrors the official `spatie/ray` package API, so it's likely that if it exists there, it's available to use in your NodeJS project.
+
+### Enabling and disabling
+
+Ray can be enabled or disabled at runtime using `enable()` or `disable()`.
+
+```js
+ray('this is sent');
+ray().disable();
+ray('this is not sent');
+ray().enable();
+ray('this is also sent');
+```
+
+### Working with screens
+
+### App visibility
+
+The Ray app can be shown or hidden programmatically.
+
+```js
+ray().showApp();
+
+ray().hideApp();
+```
+
+### Payload types
+
+Ray can display payloads of several types, including JSON, file contents, images, XML, and HTML.
+
+```js
+ray().json('{"name": "John"}');
+
+ray().toJson({name: 'my object'});
+
+ray().file('test.txt');
+
+ray().image('https://placekitten.com/200/300');
+
+ray().xml('<one><two>22</two></one>');
+
+ray().html('<strong>hello</strong> world');
+```
+
+### Using colors
+
+Ray can display the data you send with different colors.
+
+Available colors:
+- green
+- orange
+- red
+- blue
+- purple
+- gray
+
+```js
+ray('this is green').green();
+
+ray('this is purple').purple();
+```
+![screenshot](/docs/ray/v1/images/colors.jpg)
+
+### Using sizes
+
+Ray can display stuff in large, normal, or small text.
+
+```js
+ray('small').small();
+
+ray('regular');
+
+ray('large').large();
+```
+
+![screenshot](/docs/ray/v1/images/sizes.jpg)
+
+### Displaying tables
+
+Ray can display an array of items formatted in a table.  Complex items such as arrays and objects are pretty-printed and highlighted to make their contents pleasant to read.
+
+```js
+ray().table(['hello world', true, [1, 2, 3], {name: 'John', age: 32}]);
+```
+
+### Counting
+
+Ray can count the number of times a piece of code is called, optionally with a specific name.
+
+```js
+for(const n in [...Array(12).keys()]) {
+    ray().count('first');
+}
+
+[1, 2].forEach(n => ray().count());
+```
+![screenshot](/docs/ray/v1/images/named-count.jpg)
+
+### Reset counters
+
+Counter values persist across multiple calls to `ray()`.  Reset all counters with `clearCounters()`:
+
+```js
+ray().count('first');
+ray().count('first');
+console.log(Ray.counters.get('first'); // displays '2'
+
+ray().clearCounters();
+console.log(Ray.counters.get('first'); // displays '0'
+```
+
+### Conditionally showing items
+
+You can conditionally show things using the `showIf` and `showWhen` methods. If you pass a truthy value, the item will be displayed.
+
+You may also pass a callback that returns a boolean value.
+
+```js
+ray('will be shown').showIf(() => true);
+
+ray('will be shown').showWhen(true);
+
+ray('will not be shown').showIf(false);
+
+ray('will not be shown').showWhen(() => false);
+```
+
+### Pausing code execution
+
+Ray can pause code execution within async code.
+
+```js
+async function test() {
+    ray('before pausing');
+
+    await ray().pause();
+
+    ray('after resuming');
+});
+
+test();
+```
+
+![screenshot](/docs/ray/v1/images/pause.jpg)
+
+
+### Displaying a notification
+
+You can use Ray to display a notification.
+
+```js
+ray().notify('This is my notification');
+```
+
+![screenshot](/docs/ray/v1/images/notification.jpg)
+
+
+### Feature demo
+
+Here's a sample script that demonstrates a number of the features, both basic and advanced.
+
+Save as `demo.js`, and run with `node demo.js`:
+
+```js
+const { ray } = require('node-ray');
+
+function test1() { 
+    return ray().count('test one');
+}
+
+function test2() {
+    return ray().count();
+}
+
+async function alternatingColorCounter() {
+    return new Promise(resolve => {
+        const myRay = ray();
+
+        for(const i in [...Array(10).keys()]) {
+            setTimeout( () => {
+                const colorName = ['green', 'red', 'blue', 'orange'][i % 4];
+
+                myRay.html(`counter: <strong>${i + 1}</strong>`).color(colorName);
+
+                if (i === 9) {
+                    resolve(true);
+                }
+            }, i * 1500);
+        }
+    });
+}
+
+async function main() {
+    ray().showApp();
+
+    ray().xml('<one><two><three>3333</three></two></one>');
+
+    ray().table(['a string', true, [1, 2, 3], {a:1, b:2}]);
+
+    ray().sendCustom({ name: 'object' });
+
+    await alternatingColorCounter();
+
+    await ray().pause();
+
+    [1,2].forEach(n => test1());
+
+    [1,2,3,4].forEach(n => test2());
+
+    ray().image('https://placekitten.com/200/300').blue();
+
+    ray().html('<strong>hello world</strong>').small();
+}
+
+main();
+```

--- a/docs/usage/reference.md
+++ b/docs/usage/reference.md
@@ -177,6 +177,38 @@ Read more on [Craft](/docs/ray/v1/usage/craft)
 | `ray(…).showIf(true)` | Conditionally show things based on a truthy value or callable  |
 | `ray(…).size('small')` | Output text smaller or bigger. Use `large` or `small`|
 
+## NodeJS
+
+| Call | Description |
+| --- | --- |
+| `ray(variable)` | Display a string, array or object |
+| `ray(variable, another, …)` | Ray accepts multiple arguments |
+| `ray(…).blue()` | Output in color. Use `green`, `orange`, `red`, `blue`,`purple` or `gray` |
+| `ray().clearScreen()` | Clear current screen |
+| `ray().clearAll()` | Clear current and all previous screens |
+| `ray().count(name)` | Count how many times a piece of code is called, with optional name |
+| `ray().disable()` | Disable sending stuff to Ray |
+| `ray().disabled()` | Check if Ray is disabled |
+| `ray().enable()` | Enable sending stuff to Ray |
+| `ray().enabled()` | Check if Ray is enabled |
+| `ray().file(filename)` | Display contents of a file |
+| `ray(…).hide()` | Display something in Ray and make it collapse immediately |
+| `ray().hideApp()` | Programmatically hide the Ray app window |
+| `ray().html(string)` | Send HTML to Ray | 
+| `ray().image(url)` | Display an image in Ray | 
+| `ray().json([…])` | Send JSON to Ray | 
+| `ray().newScreen()` | Start a new screen |
+| `ray().newScreen('title')` | Start a new named screen |
+| `ray(…).notify(message)` | Display a notification |
+| `ray(…).pass(variable)` | Display something in Ray and return the value instead of a Ray instance |
+| `ray().pause()` | Pause code execution within your code; must be called using `await` |
+| `ray().showApp()` | Programmatically show the Ray app window |
+| `ray(…).showIf(true)` | Conditionally show things based on a truthy value or callable  |
+| `ray(…).showWhen(true)` | Conditionally show things based on a truthy value or callable  |
+| `ray(…).small()` | Output text smaller or bigger. Use `large` or `small`|
+| `ray().table([…])` | Display an array of items formatted as a table; Objects and arrays are pretty-printed |
+| `ray().xml(string)` | Send XML to Ray | 
+
 ### Updating a Ray instance
 
 | Call | Description |


### PR DESCRIPTION
This PR adds documentation for using the NodeJS-specific [node-ray package](https://github.com/permafrost-dev/node-ray).  The package is specific to NodeJS code (it uses a disk-based configuration file, reads file contents, accesses the node process methods, etc.).
 
The `node-ray` package is functionally distinct from the `js-ray` package already contained in the docs. 
I believe the updates included in the PR are worthwhile additions and will add value to Ray in general.