### PR TITLE
Update NodeJS docs

### DIFF
--- a/docs/installation-in-your-project/nodejs.md
+++ b/docs/installation-in-your-project/nodejs.md
@@ -6,3 +6,14 @@ weight: 7
 You can send information from NodeJS code (JavaScript or TypeScript) to Ray via this third party package:
 
 [permafrost-dev/node-ray](https://github.com/permafrost-dev/node-ray)
+
+### Installing the package
+
+You can install this third-party package using either `npm` or `yarn`:
+
+```bash
+npm install node-ray
+
+yarn add node-ray
+```
+

--- a/docs/usage/nodejs.md
+++ b/docs/usage/nodejs.md
@@ -19,6 +19,18 @@ ray('this is also sent');
 
 ### Working with screens
 
+Ray can create or clear new screens of information.
+
+```js
+ray().newScreen();
+
+ray().newScreen('my new screen');
+
+ray().clearScreen();
+
+ray().clearAll();
+```
+
 ### App visibility
 
 The Ray app can be shown or hidden programmatically.
@@ -159,6 +171,35 @@ ray().notify('This is my notification');
 
 ![screenshot](/docs/ray/v1/images/notification.jpg)
 
+
+### Working with errors
+
+Ray can display information about an `Error` or exception with the `error` method.
+
+```js
+ray().error(new Error('my error message'));
+```
+
+### Displaying class information
+
+You can display the classname of an object with `className()`.
+
+```js
+const obj = new MyClass1();
+
+ray().className(obj);
+```
+
+### Working with dates
+
+Ray can display information about a date in a nicely formatted table using the `date()` method.
+Specifying the format is optional. It uses the [dayjs formatting](https://day.js.org/docs/en/display/format) style.
+
+```js
+ray().date(new Date(), 'YYYY-MM-DD hh:mm');
+```
+
+![screenshot](/docs/ray/v1/images/carbon.jpg)
 
 ### Feature demo
 

--- a/docs/usage/nodejs.md
+++ b/docs/usage/nodejs.md
@@ -5,6 +5,36 @@ weight: 7
 
 The API for the NodeJS package closely mirrors the official `spatie/ray` package API, so it's likely that if it exists there, it's available to use in your NodeJS project.
 
+### Importing the package
+
+When working with NodeJS, import the package as you would normally:
+
+```js 
+// es module import:
+import { ray } from 'node-ray';
+
+// commonjs import:
+const ray = require('node-ray').ray;
+```
+
+When creating a bundle for use within a browser-based environment _(i.e. with webpack)_, import the `/web` variant:
+
+```js 
+// es module import:
+import { ray } from 'node-ray/web';
+
+// commonjs import:
+const ray = require('node-ray/web').ray;
+```
+
+To use `node-ray` directly in a webpage, include the standalone umd-format script via CDN. The standalone version is bundled with everything _except_ the axios library, which must be included separately and before the standalone script.
+Once imported, you may access the helper `ray()` function as `Ray.ray()`.
+
+```html
+    <script src="https://cdn.jsdelivr.net/npm/axios@latest"></script>
+    <script src="https://cdn.jsdelivr.net/npm/node-ray@latest/dist/standalone.js"></script>
+```
+
 ### Enabling and disabling
 
 Ray can be enabled or disabled at runtime using `enable()` or `disable()`.

--- a/docs/usage/nodejs.md
+++ b/docs/usage/nodejs.md
@@ -31,6 +31,8 @@ ray().clearScreen();
 ray().clearAll();
 ```
 
+![screenshot](/docs/ray/v1/images/screen.jpg)
+
 ### App visibility
 
 The Ray app can be shown or hidden programmatically.
@@ -54,9 +56,9 @@ ray().file('test.txt');
 
 ray().image('https://placekitten.com/200/300');
 
-ray().xml('<one><two>22</two></one>');
-
 ray().html('<strong>hello</strong> world');
+
+ray().xml('<one><two>22</two></one>');
 ```
 
 ### Using colors
@@ -196,7 +198,7 @@ Ray can display information about a date in a nicely formatted table using the `
 Specifying the format is optional. It uses the [dayjs formatting](https://day.js.org/docs/en/display/format) style.
 
 ```js
-ray().date(new Date(), 'YYYY-MM-DD hh:mm');
+ray().date(new Date(), 'YYYY-MM-DD hh:mm:ss');
 ```
 
 ![screenshot](/docs/ray/v1/images/carbon.jpg)

--- a/docs/usage/reference.md
+++ b/docs/usage/reference.md
@@ -194,6 +194,7 @@ Read more on [Craft](/docs/ray/v1/usage/craft)
 | `ray().disabled()` | Check if Ray is disabled |
 | `ray().enable()` | Enable sending stuff to Ray |
 | `ray().enabled()` | Check if Ray is enabled |
+| `ray().error(err)` | Display information about an error or exception |
 | `ray().file(filename)` | Display contents of a file |
 | `ray(…).hide()` | Display something in Ray and make it collapse immediately |
 | `ray().hideApp()` | Programmatically hide the Ray app window |

--- a/docs/usage/reference.md
+++ b/docs/usage/reference.md
@@ -19,6 +19,7 @@ To display something in Ray use the `ray()` function. It accepts everything: str
 - [Yii](#yii)
 - [Craft](#craft)
 - [Javascript](#javascript)
+- [NodeJS](#nodejs)
 
 ## Framework agnostic PHP
 
@@ -187,6 +188,8 @@ Read more on [Craft](/docs/ray/v1/usage/craft)
 | `ray().clearScreen()` | Clear current screen |
 | `ray().clearAll()` | Clear current and all previous screens |
 | `ray().count(name)` | Count how many times a piece of code is called, with optional name |
+| `ray().date(date, format)` | Display a formatted date, the timezone, and its timestamp | 
+| `ray().die()` | Halt code execution - NodeJS only |
 | `ray().disable()` | Disable sending stuff to Ray |
 | `ray().disabled()` | Check if Ray is disabled |
 | `ray().enable()` | Enable sending stuff to Ray |


### PR DESCRIPTION
This PR further updates the NodeJS docs with the following:

To the usage reference:
- adds NodeJS to the TOC
- adds `die()` for NodeJS
- adds `date()` for NodeJS
- adds `error()` for NodeJS

To the installation docs:
- adds installation examples with `npm` and `yarn`

To the NodeJS usage:
- adds examples and description on importing the `ray()` function
- adds examples, description and screenshots for section on screens
- adds examples and description for errors & exceptions
- adds examples and description of displaying object classnames
- adds examples and description for working with dates