### PR TITLE
Allow symfony/stopwatch 4.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         "ramsey/uuid": "^3.0|^4.1",
         "spatie/backtrace": "^1.0",
         "spatie/macroable": "^1.0",
-        "symfony/stopwatch": "^5.1",
+        "symfony/stopwatch": "^4.0|^5.1",
         "symfony/var-dumper": "^4.2|^5.1"
     },
     "require-dev": {


### PR DESCRIPTION
Some components of Magento 2.3 have a dependency on symfony/stopwatch ^4.0. It looks like this version would still provide the necessary functionality required for Ray. Merging this change would allow the spatie/ray composer package to be installed with Magento 2.3 without any end-user workarounds like such:

```json
"require": {
        "symfony/stopwatch": "4.4.16 as 5.1"
}
```

Cheers!