### PR TITLE
Update NodeJS docs (update 2)

### DIFF
--- a/docs/configuration/nodejs.md
+++ b/docs/configuration/nodejs.md
@@ -3,6 +3,7 @@ title: NodeJS
 weight: 8
 ---
 
+## NodeJS configuration
 In NodeJS based projects, you can optionally create a `ray.config.js` file in your project directory. It's recommended to put `ray.config.js` in your `.gitignore` so your fellow developers can use their own configuration.
 
 You can use this template as [the ray config file](/docs/ray/v1/configuration/nodejs):
@@ -26,3 +27,28 @@ module.exports = {
     port: 23517,
 }
 ```
+
+## Browser configuration
+
+This section only applies if you are using `node-ray` in a browser environment _(webpack, etc.)_.
+
+You can configure `node-ray` by importing the `Ray` class and calling the `useDefaultSettings()` method.
+
+```js
+const { Ray, ray } = require('node-ray');
+
+// set several settings at once:
+Ray.useDefaultSettings({ 
+    host: '192.168.1.20',
+    port: 23517 
+});
+
+// or set individual settings only:
+Ray.useDefaultSettings({ port: 23517 });
+
+// use ray() normally:
+ray().html('<strong>hello world</strong>');
+```
+
+These settings persist across calls to `ray()`, so they only need to be defined once.
+

--- a/docs/usage/nodejs.md
+++ b/docs/usage/nodejs.md
@@ -233,6 +233,60 @@ ray().date(new Date(), 'YYYY-MM-DD hh:mm:ss');
 
 ![screenshot](/docs/ray/v1/images/carbon.jpg)
 
+
+### Measuring performance
+
+You can use the `measure` function to display runtime and memory usage. When `measure` is called again, the time between
+this and previous call is also displayed.
+
+```js
+const sleep = (seconds) => {
+    const start = new Date().getTime();
+    while (new Date().getTime() < start + (seconds * 1000)) { }
+};
+
+ray().measure();
+
+sleep(1);
+
+ray().measure();
+
+sleep(2);
+
+ray().measure();
+```
+
+![screenshot](/docs/ray/v1/images/measure.jpg)
+
+The `measure` call optionally accepts a callable. Ray will output the time needed to run the callable and the maximum
+memory used.
+
+```js
+const sleep = (seconds) => {
+    const start = new Date().getTime();
+    while (new Date().getTime() < start + (seconds * 1000)) { }
+};
+
+ray().measure(() => {
+    sleep(5);
+});
+```
+
+The `stopTime` method can remove a stopwatch if you've previous called `measure()` with a name:
+```js
+
+ray().measure('my timer');
+
+sleep(1);
+
+ray().measure('my timer');
+
+ray().stopTime('my timer');
+```
+
+Calling `stopTime()` without specifying a name will delete all existing stopwatches.
+
+
 ### Feature demo
 
 Here's a sample script that demonstrates a number of the features, both basic and advanced.

--- a/docs/usage/nodejs.md
+++ b/docs/usage/nodejs.md
@@ -14,7 +14,7 @@ When working with NodeJS, import the package as you would normally:
 import { ray } from 'node-ray';
 
 // commonjs import:
-const ray = require('node-ray').ray;
+const { ray } = require('node-ray');
 ```
 
 When creating a bundle for use within a browser-based environment _(i.e. with webpack)_, import the `/web` variant:
@@ -24,15 +24,18 @@ When creating a bundle for use within a browser-based environment _(i.e. with we
 import { ray } from 'node-ray/web';
 
 // commonjs import:
-const ray = require('node-ray/web').ray;
+const { ray } = require('node-ray/web');
 ```
 
 To use `node-ray` directly in a webpage, include the standalone umd-format script via CDN. The standalone version is bundled with everything _except_ the axios library, which must be included separately and before the standalone script.
-Once imported, you may access the helper `ray()` function as `Ray.ray()`.
 
 ```html
     <script src="https://cdn.jsdelivr.net/npm/axios@latest"></script>
     <script src="https://cdn.jsdelivr.net/npm/node-ray@latest/dist/standalone.js"></script>
+    <script>
+        window.ray = Ray.ray;
+        window.Ray = Ray.Ray;
+    </script>
 ```
 
 ### Enabling and disabling

--- a/docs/usage/reference.md
+++ b/docs/usage/reference.md
@@ -201,6 +201,8 @@ Read more on [Craft](/docs/ray/v1/usage/craft)
 | `ray().html(string)` | Send HTML to Ray | 
 | `ray().image(url)` | Display an image in Ray | 
 | `ray().json([…])` | Send JSON to Ray | 
+| `ray().measure(callable)` | Measure the performance of a callback function |
+| `ray().measure()` | Begin measuring the overall time and elapsed time since previous `measure()` call |
 | `ray().newScreen()` | Start a new screen |
 | `ray().newScreen('title')` | Start a new named screen |
 | `ray(…).notify(message)` | Display a notification |
@@ -210,6 +212,7 @@ Read more on [Craft](/docs/ray/v1/usage/craft)
 | `ray(…).showIf(true)` | Conditionally show things based on a truthy value or callable  |
 | `ray(…).showWhen(true)` | Conditionally show things based on a truthy value or callable  |
 | `ray(…).small()` | Output text smaller or bigger. Use `large` or `small`|
+| `ray().stopTime(name)` | Removes a named stopwatch if specified, otherwise removes all stopwatches |
 | `ray().table([…])` | Display an array of items formatted as a table; Objects and arrays are pretty-printed |
 | `ray().xml(string)` | Send XML to Ray | 
 


### PR DESCRIPTION
This PR updates the NodeJS docs with the following:

- updates import examples for NodeJS, browser-based bundle, and browser-based standalone via script tags
- adds configuration description and example for configuring the `node-ray` package when using it within a browser environment
- adds section on '_Measuring performance_', with explanations and examples for `measure()` and `stopTime()`