### PR TITLE
Fix Client cache fingerprint initialization

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -20,7 +20,7 @@ class Client
 
     public function __construct(int $portNumber = 23517, string $host = 'localhost')
     {
-        $this->fingerprint = md5($this->host . ':' . $this->portNumber);
+        $this->fingerprint = $host . ':' . $portNumber;
 
         $this->portNumber = $portNumber;
 


### PR DESCRIPTION
This PR fixes the initialization of the Client's cache fingerprint property as it was trying to access `$this->host` and `$this->portNumber` instead of just `$host` and `$portNumber`.  It also removes the call to `md5()` as it was not necessary.

Resolves #290.