### PR TITLE
Fix enabled status

### DIFF
--- a/src/Ray.php
+++ b/src/Ray.php
@@ -65,8 +65,8 @@ class Ray
     /** @var \Symfony\Component\Stopwatch\Stopwatch[] */
     public static $stopWatches = [];
 
-    /** @var bool */
-    public static $enabled = true;
+    /** @var bool|null */
+    public static $enabled = null;
 
     public static function create(Client $client = null, string $uuid = null): self
     {
@@ -85,7 +85,7 @@ class Ray
 
         $this->uuid = $uuid ?? static::$fakeUuid ?? Uuid::uuid4()->toString();
 
-        static::$enabled = $this->settings->enable !== false;
+        static::$enabled = static::$enabled ?? $this->settings->enable !== false;
     }
 
     public function enable(): self

--- a/src/Ray.php
+++ b/src/Ray.php
@@ -85,7 +85,7 @@ class Ray
 
         $this->uuid = $uuid ?? static::$fakeUuid ?? Uuid::uuid4()->toString();
 
-        static::$enabled = static::$enabled ?? $this->settings->enable !== false;
+        static::$enabled = static::$enabled ?? $this->settings->enable ?? true;
     }
 
     public function enable(): self
@@ -104,12 +104,12 @@ class Ray
 
     public function enabled(): bool
     {
-        return static::$enabled;
+        return static::$enabled || static::$enabled === null;
     }
 
     public function disabled(): bool
     {
-        return ! static::$enabled;
+        return static::$enabled === false;
     }
 
     public static function useClient(Client $client): void

--- a/tests/RayTest.php
+++ b/tests/RayTest.php
@@ -798,6 +798,25 @@ class RayTest extends TestCase
         $this->assertFalse($this->client->performAvailabilityCheck());
     }
 
+    /** @test */
+    public function it_respects_the_enabled_property()
+    {
+        $ray = $this->getNewRay()->disable();
+
+        $this->assertFalse($ray->enabled());
+        $this->assertFalse($this->getNewRay()->enabled());
+
+        getRay()->enable();
+
+        $this->assertTrue($ray->enabled());
+        $this->assertTrue($this->getNewRay()->enabled());
+    }
+
+    protected function getNewRay(): Ray
+    {
+        return Ray::create($this->client, 'fakeUuid');
+    }
+
     protected function getValueOfLastSentContent(string $contentKey)
     {
         $payload = $this->client->sentPayloads();

--- a/tests/RayTest.php
+++ b/tests/RayTest.php
@@ -36,6 +36,8 @@ class RayTest extends TestCase
         $this->settings = SettingsFactory::createFromConfigFile();
 
         $this->ray = new Ray($this->settings, $this->client, 'fakeUuid');
+
+        $this->ray->enable();
     }
 
     /** @test */
@@ -806,7 +808,7 @@ class RayTest extends TestCase
         $this->assertFalse($ray->enabled());
         $this->assertFalse($this->getNewRay()->enabled());
 
-        getRay()->enable();
+        $this->getNewRay()->enable();
 
         $this->assertTrue($ray->enabled());
         $this->assertTrue($this->getNewRay()->enabled());

--- a/tests/RayTest.php
+++ b/tests/RayTest.php
@@ -814,6 +814,22 @@ class RayTest extends TestCase
         $this->assertTrue($this->getNewRay()->enabled());
     }
 
+    /** @test */
+    public function it_respects_the_enabled_property_when_sending_payloads()
+    {
+        $ray = $this->getNewRay()->disable();
+        $ray->send('test message 1');
+        $this->assertCount(0, $this->client->sentPayloads());
+
+        $ray->enable();
+        $ray->send('test message 2');
+        $this->assertCount(1, $this->client->sentPayloads());
+
+        $ray->disable();
+        $ray->send('test message 3');
+        $this->assertCount(1, $this->client->sentPayloads());
+    }
+
     protected function getNewRay(): Ray
     {
         return Ray::create($this->client, 'fakeUuid');


### PR DESCRIPTION
This PR fixes a bug that caused the `Ray::$enabled` property not to be persisted across multiple creations of the `Ray` class.  As a result, `Ray` was sending data to the Ray app even when the class was "disabled" and should not have been attempting to send the payloads.