### PR TITLE
Add Vue docs

### DIFF
--- a/docs/installation-in-your-project/vue.md
+++ b/docs/installation-in-your-project/vue.md
@@ -1,0 +1,43 @@
+---
+title: Vue
+weight: 8
+---
+
+You can send information from Vue (2.x or 3.x) code to Ray via this third party package:
+
+[permafrost-dev/vue-ray](https://github.com/permafrost-dev/vue-ray)
+
+### Installing the package
+
+You can install this third-party package using either `npm` or `yarn`:
+
+```bash
+npm install vue-ray
+
+yarn add vue-ray
+```
+
+### Installing in Vue 3
+
+When using in a Vue 3.x project, import the package and install the plugin in your entry file:
+
+```js 
+import { createApp } from 'vue';
+import App from './App.vue';
+import RayPlugin from 'vue-ray';
+
+const app = createApp(App);
+
+app.use(RayPlugin, { interceptErrors: true, host: '127.0.0.1', port: 23517 });
+```
+
+### Installing in Vue 2
+
+When using in a Vue 2.x project, import the 'vue2' export variant and install the plugin in your entry file:
+
+```js 
+const Vue = require('vue');
+const { RayPlugin } = require('vue-ray/vue2');
+
+Vue.use(RayPlugin, { interceptErrors: true, host: '127.0.0.1', port: 23517 });
+```

--- a/docs/usage/reference.md
+++ b/docs/usage/reference.md
@@ -20,6 +20,7 @@ To display something in Ray use the `ray()` function. It accepts everything: str
 - [Craft](#craft)
 - [Javascript](#javascript)
 - [NodeJS](#nodejs)
+- [Vue](#vue)
 
 ## Framework agnostic PHP
 
@@ -215,6 +216,14 @@ Read more on [Craft](/docs/ray/v1/usage/craft)
 | `ray().stopTime(name)` | Removes a named stopwatch if specified, otherwise removes all stopwatches |
 | `ray().table([…])` | Display an array of items formatted as a table; Objects and arrays are pretty-printed |
 | `ray().xml(string)` | Send XML to Ray | 
+
+## Vue
+
+| Call | Description |
+| --- | --- |
+| `this.$ray().data()` | Send the component data object to Ray |
+| `this.$ray().props()` | Send the component props to Ray |
+| `this.$ray().ref(name)` | Display the `innerHTML` of a named ref in Ray |
 
 ### Updating a Ray instance
 

--- a/docs/usage/vue.md
+++ b/docs/usage/vue.md
@@ -1,0 +1,106 @@
+---
+title: Vue
+weight: 8
+---
+
+The third-party Vue package for Ray uses the NodeJS package for most core functionality; see the [NodeJS reference](/docs/ray/v1/usage/nodejs) for a full list of available methods.
+
+Once the plugin is installed, you may access the helper function as `this.$ray()` from within your Vue components.
+
+### Component data
+
+A component's data object can be displayed in Ray with the `data()` method.
+
+```vue
+<template>
+    <div class="w-full">{{ msg }}</div>
+</template>
+
+<script>
+export default {
+    data() {
+        return {
+            msg: 'hello world'
+        }
+    },
+    mounted() {
+        this.$ray().data();
+    }
+}
+</script>
+```
+
+### Component props
+
+A component's props _(names and values)_ can be pretty-printed in Ray with the `props()` method.
+
+```vue
+<template>
+    <div class="w-full">{{ msg }}</div>
+</template>
+
+<script>
+export default {
+    props: ['msg'],
+    mounted() {
+        this.$ray().props();
+    }
+}
+</script>
+```
+
+### Displaying refs
+
+A named ref's `innerHTML` contents can be sent to ray with the `ref()` method.
+
+
+```vue
+<template>
+    <div ref="msg" class="w-full text-blue-500 p-5">
+        <strong>hello world</strong>
+    </div>
+</template>
+
+<script>
+export default {
+    mounted() {
+        this.$ray().ref('msg');
+    }
+}
+</script>
+```
+
+### Example component
+
+```vue
+<template>
+    <div class="flex-col border-r border-gray-200 bg-white overflow-y-auto w-100">
+        <div class="about">
+            <h1>{{ title }}</h1>
+            <a @click="sendToRay()">send ref to Ray</a>
+        </div>
+        <div ref="div1" class="w-full flex flex-wrap">
+            <div ref="div1a" class="w-4/12 inline-flex">one</div>
+            <div ref="div1b" class="w-4/12 inline-flex">two</divr>
+        </div>
+    </div>
+</template>
+
+<script>
+export default {
+    props: ['title'],
+    created() {
+        this.$ray().html('<em>test component created!</em>');
+    },
+    mounted() {
+        this.$ray('test component mounted!');
+        this.$ray().props();
+    },
+    methods: {
+        sendToRay() {
+            this.$ray().ref('div1');
+        }
+    }
+};
+</script>
+```


### PR DESCRIPTION
This PR adds documentation for using Ray with the Vue framework _(v2 & v3)_ using the third-party package [`vue-ray`](https://github.com/permafrost-dev/vue-ray), and updates the usage reference to include Vue-specific methods.

I feel it's appropriate to add these docs as documentation for using Ray with other frameworks _(Laravel, Yii, etc.)_ already exists,  will add overall value to Ray, and widen its potential user base.