### PR TITLE
Update vue docs

### DIFF
--- a/docs/installation-in-your-project/introduction.md
+++ b/docs/installation-in-your-project/introduction.md
@@ -13,6 +13,7 @@ To send information to the Ray desktop app, you'll need to install a package or 
 - [Ruby](/docs/ray/v1/installation-in-your-project/ruby)
 
 - [JavaScript](/docs/ray/v1/installation-in-your-project/javascript)
+- [NodeJS](/docs/ray/v1/installation-in-your-project/nodejs)
 - [Vue](/docs/ray/v1/installation-in-your-project/vue)
 
 - [Bash](/docs/ray/v1/installation-in-your-project/bash)

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -5,7 +5,7 @@ weight: 1
 
 [Ray](https://myray.app) is a beautiful, lightweight desktop app that helps you debug your app. There's a [free demo](https://myray.app) available that can be unlocked with a [license](https://spatie.be/products/ray).
 
-Ray supports PHP, Ruby, JavaScript and Bash applications. After installing [one of the libraries to send information to Ray](/docs/ray/v1/installation-in-your-project/introduction), you can use the `ray` function to quickly dump stuff. Any variable(s) that you pass to `ray` will be displayed.
+Ray supports PHP, Ruby, JavaScript, TypeScript, NodeJS and Bash applications. After installing [one of the libraries to send information to Ray](/docs/ray/v1/installation-in-your-project/introduction), you can use the `ray` function to quickly dump stuff. Any variable(s) that you pass to `ray` will be displayed.
 
 Here's an example for a Laravel app (for other languages the syntax is similar):
 ```

--- a/docs/usage/reference.md
+++ b/docs/usage/reference.md
@@ -221,9 +221,12 @@ Read more on [Craft](/docs/ray/v1/usage/craft)
 
 | Call | Description |
 | --- | --- |
+| `this.$ray().<method>` | All NodeJS methods [listed above](#nodejs) are also available |
 | `this.$ray().data()` | Send the component data object to Ray |
 | `this.$ray().props()` | Send the component props to Ray |
 | `this.$ray().ref(name)` | Display the `innerHTML` of a named ref in Ray |
+| `this.$ray().track(name)` | Display changes to a component's data variable in real time |
+| `this.$ray().untrack(name)` | Stop displaying changes to a component's data variable |
 
 ### Updating a Ray instance
 

--- a/docs/usage/vue.md
+++ b/docs/usage/vue.md
@@ -70,6 +70,31 @@ export default {
 </script>
 ```
 
+## Tracking component data
+
+Changes to any of a component's data variables can be tracked and displayed in real time using the `track(name)` method.
+
+```vue
+<script>
+export default {
+    props: ['title'],
+    data() {
+        return {
+            one: 100,
+            two: 22,
+        };
+    },
+    created() {
+        this.$ray().data();
+        this.$ray().track('one');
+    },
+    mounted() {
+        setInterval( () => { this.one += 3; }, 4000);
+    }
+}
+</script>
+```
+
 ### Example component
 
 ```vue


### PR DESCRIPTION
This PR updates the docs as follows:

- updates Vue usage docs with information and examples on component data variable tracking
- adds NodeJS to the installation docs TOC
- adds Typescript and NodeJS to list of supported languages in the intro docs.