### PR TITLE
Update NodeJS Docs

### DIFF
--- a/docs/usage/nodejs.md
+++ b/docs/usage/nodejs.md
@@ -81,7 +81,7 @@ ray().hideApp();
 Ray can display payloads of several types, including JSON, file contents, images, XML, and HTML.
 
 ```js
-ray().json('{"name": "John"}');
+ray().json('['a' => 1, 'b' => ['c' => 3]]');
 
 ray().toJson({name: 'my object'});
 
@@ -91,8 +91,12 @@ ray().image('https://placekitten.com/200/300');
 
 ray().html('<strong>hello</strong> world');
 
-ray().xml('<one><two>22</two></one>');
+ray().xml('<one><two><three>3</three></two></one>');
 ```
+
+![screenshot](/docs/ray/v1/images/json.png)
+
+![screenshot](/docs/ray/v1/images/xml.png)
 
 ### Using colors
 
@@ -129,11 +133,25 @@ ray('large').large();
 
 ### Displaying tables
 
-Ray can display an array of items formatted in a table.  Complex items such as arrays and objects are pretty-printed and highlighted to make their contents pleasant to read.
+Ray can display an object formatted in a table.  Complex items such as arrays and objects are pretty-printed and highlighted to make their contents pleasant to read.
 
 ```js
-ray().table(['hello world', true, [1, 2, 3], {name: 'John', age: 32}]);
+ray().table({
+    First: 'First value',
+    Second: 'Second value',
+    Third: 'Third value',
+});
 ```
+
+![screenshot](/docs/ray/v1/images/table.png)
+
+An array of items can also be displayed with formatted values.
+
+```js
+ray().table(['John', 'Paul', 'George', 'Ringo'], 'Beatles');
+```
+
+![screenshot](/docs/ray/v1/images/table-label.png)
 
 ### Counting
 
@@ -176,6 +194,25 @@ ray('will not be shown').showIf(false);
 
 ray('will not be shown').showWhen(() => false);
 ```
+
+### See the caller of a function
+
+Sometimes you want to know where your code is being called. You can quickly determine that by using the `caller`
+function.
+
+```js
+ray().caller();
+```
+
+![screenshot](/docs/ray/v1/images/caller.jpg)
+
+If you want to see the entire stack trace, use the `trace` function.
+
+```js
+ray().trace();
+```
+
+![screenshot](/docs/ray/v1/images/trace.jpg)
 
 ### Pausing code execution
 
@@ -289,6 +326,15 @@ ray().stopTime('my timer');
 
 Calling `stopTime()` without specifying a name will delete all existing stopwatches.
 
+### Showing events
+
+You can information about an event that has executed by calling `event(name, data)`, with `data` being optional.
+
+```js
+ray().event('TestEvent', ['my argument']);
+```
+
+![screenshot](/docs/ray/v1/images/event.jpg)
 
 ### Feature demo
 

--- a/docs/usage/reference.md
+++ b/docs/usage/reference.md
@@ -186,6 +186,7 @@ Read more on [Craft](/docs/ray/v1/usage/craft)
 | `ray(variable)` | Display a string, array or object |
 | `ray(variable, another, …)` | Ray accepts multiple arguments |
 | `ray(…).blue()` | Output in color. Use `green`, `orange`, `red`, `blue`,`purple` or `gray` |
+| `ray()->caller()` | Discover where code is being called |
 | `ray().clearScreen()` | Clear current screen |
 | `ray().clearAll()` | Clear current and all previous screens |
 | `ray().count(name)` | Count how many times a piece of code is called, with optional name |
@@ -196,7 +197,8 @@ Read more on [Craft](/docs/ray/v1/usage/craft)
 | `ray().enable()` | Enable sending stuff to Ray |
 | `ray().enabled()` | Check if Ray is enabled |
 | `ray().error(err)` | Display information about an error or exception |
-| `ray().file(filename)` | Display contents of a file |
+| `ray().event(name, data)` | Display information about an event with optional data |
+| `ray().file(filename)` | Display contents of a file - NodeJS only |
 | `ray(…).hide()` | Display something in Ray and make it collapse immediately |
 | `ray().hideApp()` | Programmatically hide the Ray app window |
 | `ray().html(string)` | Send HTML to Ray | 
@@ -214,7 +216,8 @@ Read more on [Craft](/docs/ray/v1/usage/craft)
 | `ray(…).showWhen(true)` | Conditionally show things based on a truthy value or callable  |
 | `ray(…).small()` | Output text smaller or bigger. Use `large` or `small`|
 | `ray().stopTime(name)` | Removes a named stopwatch if specified, otherwise removes all stopwatches |
-| `ray().table([…])` | Display an array of items formatted as a table; Objects and arrays are pretty-printed |
+| `ray().table(…)` | Display an array of items or an object formatted as a table; Objects and arrays are pretty-printed |
+| `ray()->trace()` | Check entire backtrace |
 | `ray().xml(string)` | Send XML to Ray | 
 
 ## Vue

--- a/docs/usage/vue.md
+++ b/docs/usage/vue.md
@@ -3,7 +3,8 @@ title: Vue
 weight: 8
 ---
 
-The third-party Vue package for Ray uses the NodeJS package for most core functionality; see the [NodeJS reference](/docs/ray/v1/usage/nodejs) for a full list of available methods.
+The third-party Vue package for Ray uses the [package for NodeJS]((/docs/ray/v1/installation-in-your-project/nodejs) for 
+most core functionality. See the [NodeJS reference](/docs/ray/v1/usage/nodejs) for a full list of available methods.
 
 Once the plugin is installed, you may access the helper function as `this.$ray()` from within your Vue components.
 


### PR DESCRIPTION
This PR updates the NodeJS docs to reflect the most recent additions to the `node-ray` package _(which now has a 95% compatibility with the API of the `spatie/ray` package API)_.

Specifically, it adds examples and descriptions to the reference and usage docs for the following methods:
- `caller()`
- `event()`
- `trace()`

This PR also enhances the NodeJS usage docs with existing screenshots where it makes sense, and includes a minor update to the Vue docs _(adds a link to the nodejs reference)_.