### PR TITLE
remove extra prefixing slash

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -44,7 +44,7 @@ class Client
     public function performAvailabilityCheck(): bool
     {
         try {
-            $curlHandle = $this->getCurlHandleForUrl('get', '/_availability_check');
+            $curlHandle = $this->getCurlHandleForUrl('get', '_availability_check');
 
             curl_exec($curlHandle);
 


### PR DESCRIPTION
the `getCurlHandleForUrl()` method builds the URL with the slash, so there is no need to add it at the start of $url parameter being passed in.

`"http://{$this->host}:{$this->portNumber}/{$url}"`

currently the final url returned is, for example `http://127.0.0.1:23517//_availability_check` whereas I think it should be `http://127.0.0.1:23517/_availability_check`