### PR TITLE
Update Vue docs

### DIFF
--- a/docs/installation-in-your-project/vue.md
+++ b/docs/installation-in-your-project/vue.md
@@ -42,3 +42,39 @@ const { RayPlugin } = require('vue-ray/vue2');
 
 Vue.use(RayPlugin, { interceptErrors: true, host: '127.0.0.1', port: 23517 });
 ```
+
+### Installing the Vuex plugin
+
+In either a Vue 2.x or 3.x project, using installing the vuex plugin will send the vuex state to Ray whenever a mutation is called, in a manner similar to the `track()` method.
+
+```js
+// ...
+
+import { RayVuexPlugin } from 'vue-ray'; // or 'vue-ray/vue2' if using Vue 2.x
+
+// ...
+
+const storeObj = {
+  state: {
+    one: 11,
+    two: 22,
+  },
+  mutations: {
+    incrementOne(state) {
+        state.one += 1;
+    },
+    incrementTwo(state) {
+        state.two += 2;
+    },
+  },
+  actions: {},
+  modules: {},
+  plugins: [RayVuexPlugin],
+};
+
+// Vue 3:
+export default createStore(storeObj);
+
+// Vue 2:
+export default new Vuex.Store(storeObj);
+```

--- a/docs/usage/vue.md
+++ b/docs/usage/vue.md
@@ -103,7 +103,8 @@ export default {
     <div class="flex-col border-r border-gray-200 bg-white overflow-y-auto w-100">
         <div class="about">
             <h1>{{ title }}</h1>
-            <a @click="sendToRay()">send ref to Ray</a>
+            <a @click="sendToRay()">send ref to Ray</a><br>
+            <a @click="incrementOne()">increment data var 'one'</a><br>
         </div>
         <div ref="div1" class="w-full flex flex-wrap">
             <div ref="div1a" class="w-4/12 inline-flex">one</div>
@@ -115,17 +116,27 @@ export default {
 <script>
 export default {
     props: ['title'],
+    data() {
+        one: 1,
+    },
     created() {
         this.$ray().html('<em>test component created!</em>');
     },
     mounted() {
         this.$ray('test component mounted!');
         this.$ray().props();
+        this.$ray().track('one');
+
+        //if using vuex and the vue-ray vuex plugin, display vuex state changes:
+        this.$store.commit('increment');
     },
     methods: {
         sendToRay() {
             this.$ray().ref('div1');
-        }
+        },
+        incrementOne() {
+            this.one += 1;
+        },
     }
 };
 </script>

--- a/docs/usage/vue.md
+++ b/docs/usage/vue.md
@@ -128,7 +128,7 @@ export default {
         this.$ray().track('one');
 
         //if using vuex and the vue-ray vuex plugin, display vuex state changes:
-        this.$store.commit('increment');
+        this.$store.commit('incrementOne');
     },
     methods: {
         sendToRay() {


### PR DESCRIPTION
This PR updates the Vue docs to be in sync with the latest version of the [`vue-ray`](https://github.com/permafrost-dev/vue-ray) package, 1.9.0.

Specifically, it adds instructions and examples for using the vuex plugin included with the package.

