### PR TITLE
Update PHP & NodeJS Docs

### DIFF
--- a/docs/usage/framework-agnostic-php-project.md
+++ b/docs/usage/framework-agnostic-php-project.md
@@ -446,6 +446,18 @@ ray()->phpinfo('xdebug.enabled', 'default_mimetype');
 ![screenshot](/docs/ray/v1/images/php-info.png)
 
 
+### Displaying exceptions
+
+You can display information about an Exception in Ray, including a snippet of source code showing where it was thrown.
+
+```php
+try {
+  throw new \Exception('test');
+} catch(\Exception $e) {
+  ray()->exception($e);
+}
+```
+
 ### Showing raw values
 
 When you sent certain values to Ray, such as Carbon instances or Eloquent models, these values will be displayed in nice way. To see all private, protected, and public properties of such values, you can use the `raw()` method.

--- a/docs/usage/reference.md
+++ b/docs/usage/reference.md
@@ -41,6 +41,7 @@ To display something in Ray use the `ray()` function. It accepts everything: str
 | `ray()->disabled()` | Check if Ray is disabled |
 | `ray()->enable()` | Enable sending stuff to Ray |
 | `ray()->enabled()` | Check if Ray is enabled |
+| `ray()->exception($e)` | Display information about an Exception |
 | `ray()->file($path)` | Display contents of a file |
 | `ray(…)->gray()` | Output in gray |
 | `ray(…)->green()` | Output in green |
@@ -198,6 +199,7 @@ Read more on [Craft](/docs/ray/v1/usage/craft)
 | `ray().enabled()` | Check if Ray is enabled |
 | `ray().error(err)` | Display information about an error or exception |
 | `ray().event(name, data)` | Display information about an event with optional data |
+| `ray().exception(err)` | Display extended information about an Error or Exception |
 | `ray().file(filename)` | Display contents of a file - NodeJS only |
 | `ray(…).hide()` | Display something in Ray and make it collapse immediately |
 | `ray().hideApp()` | Programmatically hide the Ray app window |


### PR DESCRIPTION
This PR updates the documentation for PHP and NodeJS.

Specifically,  it:
- updates the usage reference with the `exception()` method for both PHP and NodeJS
- adds a brief description and example code on displaying exceptions in PHP usage docs

The section added to the PHP/Framework-agnostic usage docs, "Displaying exceptions", might be a good candidate for a screenshot - the code snippet is a nice touch and should be shown off, IMO.  I did not include a screenshot for the sake of consistency - I'm not running MacOS, and all screenshots are from Mac.