### PR TITLE
Laravel Docs: add env() method

### DIFF
--- a/docs/usage/laravel.md
+++ b/docs/usage/laravel.md
@@ -207,6 +207,17 @@ collect(['a', 'b', 'c'])
 
 ![screenshot](/docs/ray/v1/images/collection.jpg)
 
+
+### Displaying environment variables
+
+You can use the `env()` method to display all environment variables as loaded from your `.env` file.  You may optionally pass an array of variable names to exclusively display.
+
+```php
+ray()->env();
+
+ray()->env(['APP_NAME', 'DB_DATABASE', 'DB_HOSTNAME', 'DB_PORT']);
+```
+
 ### Using Ray in Blade views
 
 You can use the `@ray` directive to easily send variables to Ray from inside a Blade view. You can pass as many things as you'd like.

--- a/docs/usage/reference.md
+++ b/docs/usage/reference.md
@@ -87,6 +87,7 @@ Read more on [Framework agnostic PHP](/docs/ray/v1/usage/framework-agnostic-php-
 
 | Call | Description |
 | --- | --- |
+| `ray()->env([name1, name2, ...])` | Display environment variables, optionally the specified names only |
 | `ray()->mailable($mailable)` | Render a mailable  |
 | `ray()->markdown($markdown)` | Render markdown  |
 | `ray()->model($model)` | Display the attributes and relations of a model  |


### PR DESCRIPTION
This PR adds an example and reference to the Laravel usage docs for the `env()` method.