### PR TITLE
Add docs for Alpine.js

### DIFF
--- a/docs/configuration/alpinejs.md
+++ b/docs/configuration/alpinejs.md
@@ -1,0 +1,26 @@
+---
+title: Alpine.js
+weight: 9
+---
+
+### Configuration options
+
+To configure `alpinejs-ray`, you must create an `alpineRayConfig` property on the `window` object before loading `alpinejs-ray`:
+
+```html
+<script>
+    window.alpineRayConfig = {
+        logComponentsInit: true,
+        logCustomEvents: false,
+    };
+</script>
+
+<!-- load axios and alpinejs-ray scripts here -->
+```
+
+| Name | Type | Default | Description |
+| --- | --- | --- | --- |
+| `logComponentsInit` | `boolean` | `false` | Send info on component initializations to Ray |
+| `logCustomEvents` | `boolean` | `false` | Send info on custom events to Ray _(events with hyphenated names)_ |
+
+

--- a/docs/installation-in-your-project/alpinejs.md
+++ b/docs/installation-in-your-project/alpinejs.md
@@ -1,0 +1,51 @@
+---
+title: Alpine.js
+weight: 10
+---
+
+You can send information from Alpine.js to Ray via this third party package:
+
+[permafrost-dev/alpinejs-ray](https://github.com/permafrost-dev/alpinejs-ray)
+
+### Installation via CDN
+
+The preferred way to use this package is to load it via a CDN.  You'll need to load the `axios` library as well:
+
+```html
+<script src="https://cdn.jsdelivr.net/npm/axios@latest"></script>
+<script src="https://cdn.jsdelivr.net/npm/alpinejs-ray@latest/dist/standalone.min.js"></script>
+```
+
+### Installation with package manager
+
+Install with npm:
+
+```bash
+npm install alpinejs-ray
+```
+
+or yarn:
+
+```bash
+yarn add alpinejs-ray
+```
+
+#### Importing the plugin
+
+Although not the recommended way, you can import package normally if installed with a package manager _(along with `node-ray`, `alpinejs` and `axios`)_:
+
+```js 
+import { Ray, ray } from 'node-ray/web';
+import Alpine from 'alpinejs';
+import AlpineRayPlugin from 'alpinejs-ray';
+
+window.ray = ray;
+window.Ray = Ray;
+window.axios = require('axios');
+window.axios.defaults.headers.common['X-Requested-With'] = 'XMLHttpRequest';
+
+window.Alpine = Alpine;
+window.AlpineRayPlugin = AlpineRayPlugin;
+window.AlpineRayPlugin.init();
+window.AlpineRayPlugin.start();
+```

--- a/docs/usage/alpinejs.md
+++ b/docs/usage/alpinejs.md
@@ -1,0 +1,52 @@
+---
+title: Alpine.js
+weight: 10
+---
+
+The third-party Alpine.js [package](https://github.com/permafrost-dev/alpinejs-ray) for Ray uses the [package for NodeJS](/docs/ray/v1/installation-in-your-project/nodejs) for 
+most core functionality. See the [NodeJS reference](/docs/ray/v1/usage/nodejs) for a full list of available methods.
+
+Once the plugin is installed, you may access the helper function as `$ray()` from within your Alpine components.
+
+## Example Component
+
+```html
+<div x-data="onClickData()" x-init="init()">
+    <div x-show="show">Hi There Ray!</div>
+    <button x-on:click="toggle()">Show/Hide (Ray)</button>
+    <button @click="$ray('hello from alpine')">Send to Ray</button>
+</div>
+
+<script>        
+function onClickData() {
+    return {
+        init() {
+            this.$ray().html('<strong>init on-click-ray data</strong>');
+        },
+        toggle() {
+            this.show = !this.show;
+            this.$ray('toggled show value to ' + (this.show ? 'true' : 'false'));
+        },
+        show: false,
+    };
+}
+</script>
+```
+
+## Tracking Spruce Data Stores
+
+Spruce data store are automatically tracked if [Spruce](https://github.com/ryangjchandler/spruce) is installed.  Consider the following:
+
+```js
+window.Spruce.store('mydata', {
+    showing: false,
+    toggle() {
+        this.showing = !this.showing;
+        ray().html('<strong>[spruce]</strong> showing = ' + this.showing);
+    }
+});
+ 
+setInterval( () => {
+    window.Spruce.stores.mydata.showing = !window.Spruce.stores.mydata.showing;
+}, 3000);
+```

--- a/docs/usage/reference.md
+++ b/docs/usage/reference.md
@@ -21,6 +21,7 @@ To display something in Ray use the `ray()` function. It accepts everything: str
 - [Javascript](#javascript)
 - [NodeJS](#nodejs)
 - [Vue](#vue)
+- [Alpine.js](#alpinejs)
 
 ## Framework agnostic PHP
 
@@ -233,6 +234,10 @@ Read more on [Craft](/docs/ray/v1/usage/craft)
 | `this.$ray().ref(name)` | Display the `innerHTML` of a named ref in Ray |
 | `this.$ray().track(name)` | Display changes to a component's data variable in real time |
 | `this.$ray().untrack(name)` | Stop displaying changes to a component's data variable |
+
+## AlpineJS
+
+All methods available to [NodeJS](#nodejs) are available to the Alpine.js integration.
 
 ### Updating a Ray instance
 


### PR DESCRIPTION
This PR adds documentation for the [permafrost-dev/alpinejs-ray](https://github.com/permafrost-dev/alpinejs-ray) integration library for Alpine.js.  I feel that this is a worthwhile addition to the documentation not only because the docs already contain entries for the Vue library, but also due to the growing popularity of Alpine.js.  Documentation that makes users aware that Alpine.js can be used with Ray will add value to the Ray app overall.

Specifically, this PR adds documentation to the following sections:
- installation
- configuration
- usage
- updates the usage reference