### PR TITLE
Docs: update requirements information

### DIFF
--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -7,6 +7,12 @@ All PHP packages require **PHP 7.3+** or higher.
 
 Laravel Ray requires Laravel 7 or higher.
 
-WordPress Ray requires WordPress 5.5 or higher
+WordPress Ray requires WordPress 5.5 or higher.
 
+Ruby Ray requires Ruby 3.0 or higher _(may work on 2.6+)_.
 
+Third-party package requirements:
+
+- NodeJS support _(node-ray)_ requires NodeJS 12 or higher.
+- Vue support _(vue-ray)_ requires Vue version 2.6+ **or** 3.0+. 
+- AlpineJS support _(alpinejs-ray)_ requires Alpine.js 2.5.0 or higher.


### PR DESCRIPTION
This PR updates the "requirements" document to include requirements for ruby-ray, node-ray, vue-ray, and alpinejs-ray.  I feel that it's important to have these requirements as visible as possible is because at a glance, Ray can appear to be a PHP-only debugging app.
Ensuring that it's clear at a glance that multiple languages are supported will add value to the Ray app and help drive license sales.