### PR TITLE
Call ray with condition

### DIFF
--- a/src/helpers.php
+++ b/src/helpers.php
@@ -58,3 +58,25 @@ if (! function_exists('rd')) {
         ray(...$args)->die();
     }
 }
+
+if(! function_exists('ray_if')) {
+    /**
+     * @param bool  $condition
+     * @param mixed ...$args
+     */
+    function ray_if($condition, ...$args) {
+        if ($condition) {
+            ray(...$args);
+        }
+    }
+}
+
+if(! function_exists('ray_unless')) {
+    /**
+     * @param bool  $condition
+     * @param mixed ...$args
+     */
+    function ray_unless($condition, ...$args) {
+        ray_if(! $condition, ...$args);
+    }
+}

--- a/tests/RayTest.php
+++ b/tests/RayTest.php
@@ -847,6 +847,22 @@ class RayTest extends TestCase
         $this->assertCount(1, $this->client->sentPayloads());
     }
 
+    /** @test */
+    public function it_can_send_using_if_condition()
+    {
+        ray_if(true,'a');
+
+        $this->assertMatchesOsSafeSnapshot($this->client->sentPayloads());
+    }
+
+    /** @test */
+    public function it_can_send_using_unless_condition()
+    {
+        ray_unless(false,'a');
+
+        $this->assertMatchesOsSafeSnapshot($this->client->sentPayloads());
+    }
+
     protected function getNewRay(): Ray
     {
         return Ray::create($this->client, 'fakeUuid');

--- a/tests/__snapshots__/RayTest__it_can_send_using_if_condition__1.json
+++ b/tests/__snapshots__/RayTest__it_can_send_using_if_condition__1.json
@@ -1,0 +1,21 @@
+[
+    {
+        "uuid": "fakeUuid",
+        "payloads": [
+            {
+                "type": "log",
+                "content": {
+                    "values": [
+                        "a"
+                    ]
+                },
+                "origin": {
+                    "file": "\/tests\/RayTest.php",
+                    "line_number": "xxx",
+                    "hostname": "fake-hostname"
+                }
+            }
+        ],
+        "meta": []
+    }
+]

--- a/tests/__snapshots__/RayTest__it_can_send_using_unless_condition__1.json
+++ b/tests/__snapshots__/RayTest__it_can_send_using_unless_condition__1.json
@@ -1,0 +1,21 @@
+[
+    {
+        "uuid": "fakeUuid",
+        "payloads": [
+            {
+                "type": "log",
+                "content": {
+                    "values": [
+                        "a"
+                    ]
+                },
+                "origin": {
+                    "file": "\/tests\/RayTest.php",
+                    "line_number": "xxx",
+                    "hostname": "fake-hostname"
+                }
+            }
+        ],
+        "meta": []
+    }
+]


### PR DESCRIPTION
Sometimes I forget to remove the ray when it's done debugging.

Just like the helpers, `ray_if` and `ray_unless` help facilitate clean and expressive code, In particular, these two helpers could often reduce a conditional block to a single line of code. That's pretty.