### PR TITLE
Allow Throwables to be logged

### DIFF
--- a/src/Ray.php
+++ b/src/Ray.php
@@ -42,6 +42,7 @@ use Spatie\Ray\Settings\Settings;
 use Spatie\Ray\Settings\SettingsFactory;
 use Spatie\Ray\Support\Counters;
 use Symfony\Component\Stopwatch\Stopwatch;
+use Throwable;
 
 class Ray
 {
@@ -436,7 +437,7 @@ class Ray
         return $this->sendRequest($payload);
     }
 
-    public function exception(Exception $exception, array $meta = []): self
+    public function exception(Throwable $exception, array $meta = []): self
     {
         $payload = new ExceptionPayload($exception, $meta);
 

--- a/tests/RayTest.php
+++ b/tests/RayTest.php
@@ -15,7 +15,6 @@ use Spatie\Ray\Settings\SettingsFactory;
 use Spatie\Ray\Tests\TestClasses\FakeClient;
 use Spatie\Snapshots\MatchesSnapshots;
 use Spatie\TestTime\TestTime;
-use Throwable;
 
 class RayTest extends TestCase
 {

--- a/tests/RayTest.php
+++ b/tests/RayTest.php
@@ -15,6 +15,7 @@ use Spatie\Ray\Settings\SettingsFactory;
 use Spatie\Ray\Tests\TestClasses\FakeClient;
 use Spatie\Snapshots\MatchesSnapshots;
 use Spatie\TestTime\TestTime;
+use Throwable;
 
 class RayTest extends TestCase
 {


### PR DESCRIPTION
This PR allows Ray to dump throwables instead of only exceptions. Because the `ExceptionPayload` class supports a `Throwable` argument, no additional changes are needed.