### PR TITLE
Add yellow as color

### DIFF
--- a/docs/usage/javascript.md
+++ b/docs/usage/javascript.md
@@ -25,6 +25,7 @@ You can colorize things your sent to ray by using the color function.
 
 ```js
 ray('this is green').color('green')
+ray('this is yellow').color('yellow')
 ray('this is orange').color('orange')
 ray('this is red').color('red')
 ray('this is blue').color('blue')

--- a/docs/usage/reference.md
+++ b/docs/usage/reference.md
@@ -279,7 +279,7 @@ All methods available to [NodeJS](#nodejs) are available to the Alpine.js integr
 | Call | Description |
 | --- | --- |
 | `ray.size('large')` | Update the size of a Ray instance. Use `large` or `small`   |
-| `ray.color('red')` | Update the color of a Ray instance. Use `green`, `orange`, `red`, `blue`,`purple` or `gray`   |
+| `ray.color('red')` | Update the color of a Ray instance. Use `green`, `yellow`, `orange`, `red`, `blue`,`purple` or `gray`   |
 | `$ray.remove()` | Remove an item from Ray   |
 | `$ray.removeWhen(true)` | Conditionally remove an item based on a truthy value or callable   |
 | `$ray.send()` | Update the content of a Ray instance  |

--- a/src/Concerns/RayColors.php
+++ b/src/Concerns/RayColors.php
@@ -10,6 +10,11 @@ trait RayColors
         return $this->color('green');
     }
 
+    public function yellow(): self
+    {
+        return $this->color('yellow');
+    }
+
     public function orange(): self
     {
         return $this->color('orange');

--- a/tests/Concerns/ConcernsTest.php
+++ b/tests/Concerns/ConcernsTest.php
@@ -25,7 +25,7 @@ class ConcernsTest extends TestCase
     public function it_sets_the_same_color_payload_as_the_method_name()
     {
         $colors = [
-            'blue', 'gray', 'green', 'orange', 'purple', 'red',
+            'blue', 'gray', 'green', 'yellow', 'orange', 'purple', 'red',
         ];
 
         $ray = new FakeRay();


### PR DESCRIPTION
For some reason I am always trying to use yellow as a color. This PR adds support for yellow in the PHP library. The Ray aplication itself has to support yellow in order for this PR to be merged of course.

I figured there may be more people which would like to use yellow as a color.