### PR TITLE
Docs: fix macOS download links

### DIFF
--- a/docs/the-ray-desktop-app/download-the-free-demo.md
+++ b/docs/the-ray-desktop-app/download-the-free-demo.md
@@ -5,8 +5,9 @@ weight: 1
 
 You can download the Ray destop application in these flavours:
 
-- [macOS](https://spatie.be/products/ray/download/macos/latest  )
-- [Windows](https://spatie.be/products/ray/download/windows/latest  )
+- [macOS (Intel)](https://spatie.be/products/ray/download/macosIntel/latest)
+- [macOS (Apple Silicon)](https://spatie.be/products/ray/download/macosAppleSilicon/latest)
+- [Windows](https://spatie.be/products/ray/download/windows/latest)
 - [Linux](https://spatie.be/products/ray/download/linux/latest)
 
 When using macOS, you can also install Ray with Homebrew: `brew install --cask ray`


### PR DESCRIPTION
This PR adds links to downloads the two macOS versions of the app and fixes the old link that is no longer working.