### PR TITLE
Feature: Access named counter values

### DIFF
--- a/docs/usage/framework-agnostic-php-project.md
+++ b/docs/usage/framework-agnostic-php-project.md
@@ -151,6 +151,18 @@ foreach (range(1, 4) as $i) {
 }
 ```
 
+You may access the value of a named counter using the  `counterValue` function.
+
+```php
+foreach (range(1, 4) as $i) {
+    ray()->count('first');
+
+    if (ray()->counterValue('first') === 2) {
+        echo "counter value is two!";
+    }
+}
+```
+
 This is how that looks like in Ray.
 
 ![screenshot](/docs/ray/v1/images/named-count.png)

--- a/docs/usage/reference.md
+++ b/docs/usage/reference.md
@@ -38,6 +38,7 @@ To display something in Ray use the `ray()` function. It accepts everything: str
 | `ray()->clearScreen()` | Clear current screen |
 | `ray()->clearAll()` | Clear current and all previous screens |
 | `ray()->count()` | Count how many times a piece of code is called |
+| `ray()->counterValue(name)` | Return the value of a named counter |
 | `ray(…)->die()` or `rd(…)` | Stop the PHP process |
 | `ray()->disable()` | Disable sending stuff to Ray |
 | `ray()->disabled()` | Check if Ray is disabled |

--- a/src/Ray.php
+++ b/src/Ray.php
@@ -414,6 +414,11 @@ class Ray
         return $this;
     }
 
+    public function counterValue(string $name): int
+    {
+        return self::$counters->get($name);
+    }
+
     public function pause(): self
     {
         $lockName = md5(time());

--- a/tests/RayTest.php
+++ b/tests/RayTest.php
@@ -761,6 +761,20 @@ class RayTest extends TestCase
     }
 
     /** @test */
+    public function it_returns_the_value_of_a_named_counter()
+    {
+        $this->assertEquals(0, ray()->counterValue('first'));
+
+        ray()->count('first');
+
+        $this->assertEquals(1, ray()->counterValue('first'));
+
+        ray()->count('first');
+
+        $this->assertEquals(2, ray()->counterValue('first'));
+    }
+
+    /** @test */
     public function it_will_respect_the_raw_values_config_setting()
     {
         $this->settings->always_send_raw_values = true;


### PR DESCRIPTION
This PR adds the `counterValue()` method referenced in #416.  

Specifically, it:

- Adds the `counterValue($name)` method to provide a convenient way to access the value of a named counter.
- Adds a unit test for the `counterValue` method.
- Updates the documentation with the `counterValue` method + examples.