### PR TITLE
mention send_exceptions_to_ray in the laravel settings docs

### DIFF
--- a/docs/configuration/laravel.md
+++ b/docs/configuration/laravel.md
@@ -56,6 +56,11 @@ return [
     'send_views_to_ray' => env('SEND_VIEWS_TO_RAY', false),
 
     /*
+     * When enabled, all exceptions will be automatically sent to Ray.
+     */
+    'send_exceptions_to_ray' => env('SEND_EXCEPTIONS_TO_RAY', true),
+
+    /*
     * The host used to communicate with the Ray app.
     * When using Docker on Mac or Windows, you can replace localhost with 'host.docker.internal'
     * When using Homestead with the VirtualBox provider, you can replace localhost with '10.0.2.2'


### PR DESCRIPTION
https://github.com/spatie/laravel-ray/issues/184

Is this stable to mention in the docs yet? We might also need to uncomment this part: https://github.com/spatie/laravel-ray/blob/master/src/Watchers/ApplicationLogWatcher.php#L59