### PR TITLE
Feature: add text method

### DIFF
--- a/docs/usage/framework-agnostic-php-project.md
+++ b/docs/usage/framework-agnostic-php-project.md
@@ -320,6 +320,15 @@ To render a piece of HTML directly in Ray, you can use the `html` method.
 ray()->html('<b>Bold string<b>');
 ```
 
+### Displaying text content
+
+To display raw text while preserving whitespace formatting, use the `text` method.  If the text contains HTML, it will be displayed as-is and is not rendered.
+
+```php
+ray()->text('<em>this string is html encoded</em>');
+ray()->text('  whitespace formatting' . PHP_EOL . '   is preserved as well.');
+```
+
 ### Updating displayed items
 
 You can update values that are already displayed in Ray. To do this, you must hold on the instance returned by the `ray`

--- a/docs/usage/reference.md
+++ b/docs/usage/reference.md
@@ -70,6 +70,7 @@ To display something in Ray use the `ray()` function. It accepts everything: str
 | `ray(…)->showIf(true)` | Conditionally show things based on a truthy value or callable  |
 | `ray(…)->small()` | Output text smaller |
 | `ray()->table($array. $label)` | Format an associative array with optional label  |
+| `ray()->text($string)` | Display the raw text for a string while preserving whitespace formatting  |
 | `ray()->toJson($variable, $another, … )` | Display the JSON representation of 1 or more values that can be converted |
 | `ray()->trace()` | Check entire backtrace |
 | `ray()->xml($xmlString)` | Display formatted XML in Ray |

--- a/src/Payloads/TextPayload.php
+++ b/src/Payloads/TextPayload.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Spatie\Ray\Payloads;
+
+class TextPayload extends Payload
+{
+    /** @var string */
+    protected $text;
+
+    public function __construct(string $text = '')
+    {
+        $this->text = $text;
+    }
+
+    public function getType(): string
+    {
+        return 'custom';
+    }
+
+    public function getContent(): array
+    {
+        return [
+            'content' => $this->formatContent(),
+            'label' => 'Text',
+        ];
+    }
+
+    protected function formatContent(): string
+    {
+        $result = htmlspecialchars($this->text, ENT_QUOTES | ENT_HTML5);
+
+        return str_replace([' ', PHP_EOL], ['&nbsp;', '<br>'], $result);
+    }
+}

--- a/src/Ray.php
+++ b/src/Ray.php
@@ -36,6 +36,7 @@ use Spatie\Ray\Payloads\RemovePayload;
 use Spatie\Ray\Payloads\ShowAppPayload;
 use Spatie\Ray\Payloads\SizePayload;
 use Spatie\Ray\Payloads\TablePayload;
+use Spatie\Ray\Payloads\TextPayload;
 use Spatie\Ray\Payloads\TracePayload;
 use Spatie\Ray\Payloads\XmlPayload;
 use Spatie\Ray\Settings\Settings;
@@ -456,6 +457,13 @@ class Ray
     public function xml(string $xml): self
     {
         $payload = new XmlPayload($xml);
+
+        return $this->sendRequest($payload);
+    }
+
+    public function text(string $text): self
+    {
+        $payload = new TextPayload($text);
 
         return $this->sendRequest($payload);
     }

--- a/tests/RayTest.php
+++ b/tests/RayTest.php
@@ -713,6 +713,19 @@ class RayTest extends TestCase
     }
 
     /** @test */
+    public function it_sends_a_text_payload()
+    {
+        $this->ray->text('text string');
+        $this->ray->text('another   <strong>text</strong>' . PHP_EOL . '  string');
+
+        $lastPayload = $this->client->sentPayloads()[1]['payloads'][0];
+
+        $this->assertStringContainsString('&nbsp;&nbsp;&nbsp;&lt;strong&gt;', $lastPayload['content']['content']);
+        $this->assertStringContainsString('<br>', $lastPayload['content']['content']);
+        $this->assertMatchesOsSafeSnapshot($this->client->sentPayloads());
+    }
+
+    /** @test */
     public function it_sends_a_null_payload()
     {
         $this->ray->send(null);

--- a/tests/__snapshots__/RayTest__it_sends_a_text_payload__1.json
+++ b/tests/__snapshots__/RayTest__it_sends_a_text_payload__1.json
@@ -1,0 +1,38 @@
+[
+    {
+        "uuid": "fakeUuid",
+        "payloads": [
+            {
+                "type": "custom",
+                "content": {
+                    "content": "text&nbsp;string",
+                    "label": "Text"
+                },
+                "origin": {
+                    "file": "\/tests\/RayTest.php",
+                    "line_number": "xxx",
+                    "hostname": "fake-hostname"
+                }
+            }
+        ],
+        "meta": []
+    },
+    {
+        "uuid": "fakeUuid",
+        "payloads": [
+            {
+                "type": "custom",
+                "content": {
+                    "content": "another&nbsp;&nbsp;&nbsp;&lt;strong&gt;text&lt;\/strong&gt;<br>&nbsp;&nbsp;string",
+                    "label": "Text"
+                },
+                "origin": {
+                    "file": "\/tests\/RayTest.php",
+                    "line_number": "xxx",
+                    "hostname": "fake-hostname"
+                }
+            }
+        ],
+        "meta": []
+    }
+]


### PR DESCRIPTION
This PR adds a `text()` method to the Ray class, as well as a `TextPayload` payload class.

In the `TextPayload` class, all HTML entities are encoded using `htmlspecialchars()`.  Spaces are encoded as well, and new line characters are replaced with `<br>`, effectively preserving all whitespace formatting.

I believe adding this method makes sense because `Ray` already has `html()`, `xml()`, and `json()`.  Adding a `text()` method will follow this trend and improve the developer experience.

This PR also:
- Includes a unit test for `text()`.
- Updates the documentation.