### PR TITLE
Add Ray::once() method

### DIFF
--- a/docs/usage/framework-agnostic-php-project.md
+++ b/docs/usage/framework-agnostic-php-project.md
@@ -210,15 +210,15 @@ To only send a payload once, use the `once` function.  This is useful for debugg
 
 
 ```php
-for ($i = 0; $i < 10; $i++) {
+foreach (range(1, 10) as $i) {
     ray()->once($i); // only sends "0"
 }
 ```
 
-or without arguments:
+You can also use `once` without arguments. Any function you chain on `once` will also only be called once.
 
 ```php
-for ($i = 0; $i < 10; $i++) {
+foreach (range(1, 10) as $i) {
     ray()->once()->html("<strong>{$i}</strong>"); // only sends "<strong>0</strong>"
 }
 ```

--- a/docs/usage/framework-agnostic-php-project.md
+++ b/docs/usage/framework-agnostic-php-project.md
@@ -210,7 +210,7 @@ To only send a payload once, use the `once` function.  This is useful for debugg
 
 
 ```php
-foreach ($i = 0; $i < 10; $i++) {
+for ($i = 0; $i < 10; $i++) {
     ray()->once($i); // only sends "0"
 }
 ```
@@ -218,7 +218,7 @@ foreach ($i = 0; $i < 10; $i++) {
 or without arguments:
 
 ```php
-foreach ($i = 0; $i < 10; $i++) {
+for ($i = 0; $i < 10; $i++) {
     ray()->once()->html("<strong>{$i}</strong>"); // only sends "<strong>0</strong>"
 }
 ```

--- a/docs/usage/framework-agnostic-php-project.md
+++ b/docs/usage/framework-agnostic-php-project.md
@@ -202,6 +202,27 @@ Ray::rateLimiter()->clear();
 A message to the desktop app will be sent once to notify the user the rate limit has been reached.
 
 
+### Sending a payload once
+
+To only send a payload once, use the `once` function.  This is useful for debugging loops.
+
+`once()` may be called with arguments:
+
+
+```php
+foreach ($i = 0; $i < 10; $i++) {
+    ray()->once($i); // only sends "0"
+}
+```
+
+or without arguments:
+
+```php
+foreach ($i = 0; $i < 10; $i++) {
+    ray()->once()->html("<strong>{$i}</strong>"); // only sends "<strong>0</strong>"
+}
+```
+
 ### Display the class name of an object
 
 To quickly send the class name of an object to ray, use the `className` function.

--- a/docs/usage/reference.md
+++ b/docs/usage/reference.md
@@ -60,6 +60,7 @@ To display something in Ray use the `ray()` function. It accepts everything: str
 | `ray()->newScreen()` | Start a new screen |
 | `ray()->newScreen('title')` | Start a new named screen |
 | `ray(…)->notify($message)` | Display a notification |
+| `ray()->once($arg1, …)` | Only send a payload once when in a loop |
 | `ray(…)->orange()` | Output in orange |
 | `ray(…)->pass($variable)` | Display something in Ray and return the value instead of a Ray instance |
 | `ray()->pause()` | Pause execution |

--- a/src/Ray.php
+++ b/src/Ray.php
@@ -537,6 +537,19 @@ class Ray
         return $this;
     }
 
+    public function once(...$arguments): self
+    {
+        $this->limitOrigin = (new DefaultOriginFactory())->getOrigin();
+
+        self::$limiters->initialize($this->limitOrigin, 1);
+
+        if (! empty($arguments)) {
+            return $this->send(...$arguments);
+        }
+
+        return $this;
+    }
+
     public function send(...$arguments): self
     {
         if (! count($arguments)) {

--- a/tests/RayTest.php
+++ b/tests/RayTest.php
@@ -43,6 +43,8 @@ class RayTest extends TestCase
         $this->ray = new Ray($this->settings, $this->client, 'fakeUuid');
 
         $this->ray->enable();
+
+        Ray::rateLimiter()->clear();
     }
 
     /** @test */
@@ -1045,6 +1047,28 @@ class RayTest extends TestCase
         $this->assertCount(2, $this->client->sentPayloads());
 
         $this->assertSame('Rate limit has been reached...', $this->client->sentPayloads()[1]['payloads'][0]['content']['content']);
+    }
+
+    /** @test */
+    public function it_sends_a_payload_once_when_called_with_arguments()
+    {
+        for($i = 0; $i < 5; $i++) {
+            $this->ray->once($i);
+        }
+
+        $this->assertCount(1, $this->client->sentPayloads());
+        $this->assertEquals([0], $this->client->sentPayloads()[0]['payloads'][0]['content']['values']);
+    }
+
+    /** @test */
+    public function it_sends_a_payload_once_when_called_without_arguments()
+    {
+        for($i = 0; $i < 5; $i++) {
+            $this->ray->once()->text($i);
+        }
+
+        $this->assertCount(1, $this->client->sentPayloads());
+        $this->assertEquals(0, $this->client->sentPayloads()[0]['payloads'][0]['content']['content']);
     }
 
     protected function getNewRay(): Ray

--- a/tests/RayTest.php
+++ b/tests/RayTest.php
@@ -1071,6 +1071,17 @@ class RayTest extends TestCase
         $this->assertEquals(0, $this->client->sentPayloads()[0]['payloads'][0]['content']['content']);
     }
 
+    /** @test */
+    public function it_sends_a_payload_once_while_allowing_calls_to_limit()
+    {
+        for($i = 0; $i < 5; $i++) {
+            $this->ray->once($i);
+            $this->getNewRay()->limit(5)->text($i);
+        }
+
+        $this->assertCount(6, $this->client->sentPayloads());
+    }
+
     protected function getNewRay(): Ray
     {
         return Ray::create($this->client, 'fakeUuid');

--- a/tests/RayTest.php
+++ b/tests/RayTest.php
@@ -1053,7 +1053,7 @@ class RayTest extends TestCase
     public function it_sends_a_payload_once_when_called_with_arguments()
     {
         for($i = 0; $i < 5; $i++) {
-            $this->ray->once($i);
+            $this->getNewRay()->once($i);
         }
 
         $this->assertCount(1, $this->client->sentPayloads());
@@ -1064,7 +1064,7 @@ class RayTest extends TestCase
     public function it_sends_a_payload_once_when_called_without_arguments()
     {
         for($i = 0; $i < 5; $i++) {
-            $this->ray->once()->text($i);
+            $this->getNewRay()->once()->text($i);
         }
 
         $this->assertCount(1, $this->client->sentPayloads());


### PR DESCRIPTION
This PR adds a new method to the Ray class, `once`.  It implements the feature requested in #473. 

The `once` method is a convenient helper method that allows sending a payload only once.  Its primary use case is for debugging loops.

This implementation of `once()` differs slightly from the original request.  Instead of `ray($value)->once();`, the following API was implemented:

```php
for($i = 0; $i < 5; $i++) {
   ray()->once('counter value', 'is sent once', $i);
   ray()->once()->html("<em>$i</em>");
}
```

![image](https://user-images.githubusercontent.com/5508707/123081131-a1c8d180-d3eb-11eb-9fd0-3ac1fad79417.png)

This syntax was selected over the original request because its primary use case is within loops - using `->once();` would require sending all payloads in each loop iteration followed by a removal payload.  This is not optimal in a situation where a large loop is being debugged.

This PR also:
- includes unit tests and updated documentation.
- fixes a minor bug in the `tests/RayTest.php` file that caused tests run after the rate limiter test to fail