### PR TITLE
Add url method

### DIFF
--- a/docs/usage/framework-agnostic-php-project.md
+++ b/docs/usage/framework-agnostic-php-project.md
@@ -385,6 +385,20 @@ ray()->text('<em>this string is html encoded</em>');
 ray()->text('  whitespace formatting' . PHP_EOL . '   is preserved as well.');
 ```
 
+### Displaying URLs
+
+To display a clickable link to a URL within Ray, use the `url` function.
+
+```php
+ray()->url('https://localhost:8000/products/123');
+```
+
+You may also add an optional label that will be displayed to the left of the link:
+
+```php
+ray()->url('https://localhost:8000/products/123', 'Product 123');
+```
+
 ### Updating displayed items
 
 You can update values that are already displayed in Ray. To do this, you must hold on the instance returned by the `ray`

--- a/docs/usage/reference.md
+++ b/docs/usage/reference.md
@@ -78,6 +78,7 @@ To display something in Ray use the `ray()` function. It accepts everything: str
 | `ray()->text($string)` | Display the raw text for a string while preserving whitespace formatting  |
 | `ray()->toJson($variable, $another, … )` | Display the JSON representation of 1 or more values that can be converted |
 | `ray()->trace()` | Check entire backtrace |
+| `ray()->url($url, $label)` | Display a clickable link to a URL with an optional label |
 | `ray()->xml($xmlString)` | Display formatted XML in Ray |
 
 ### Updating a Ray instance

--- a/src/Payloads/UrlPayload.php
+++ b/src/Payloads/UrlPayload.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Spatie\Ray\Payloads;
+
+class UrlPayload extends Payload
+{
+    /** @var string */
+    protected $url;
+
+    /** @var string | null */
+    protected $label;
+
+    public function __construct(string $url, ?string $label = null)
+    {
+        $this->url = $url;
+        $this->label = $label;
+    }
+
+    public function getType(): string
+    {
+        return 'custom';
+    }
+
+    public function getContent(): array
+    {
+        $label = $this->label ? "<div class=\"pr-3 inline\">{$this->label}</div>" : '';
+        $content = "{$label}<a class=\"text-blue-600 underline\" href=\"{$this->url}\">{$this->url}</a>";
+
+        return [
+            'content' => $content,
+            'label' => 'URL',
+        ];
+    }
+}

--- a/src/Ray.php
+++ b/src/Ray.php
@@ -38,6 +38,7 @@ use Spatie\Ray\Payloads\SizePayload;
 use Spatie\Ray\Payloads\TablePayload;
 use Spatie\Ray\Payloads\TextPayload;
 use Spatie\Ray\Payloads\TracePayload;
+use Spatie\Ray\Payloads\UrlPayload;
 use Spatie\Ray\Payloads\XmlPayload;
 use Spatie\Ray\Settings\Settings;
 use Spatie\Ray\Settings\SettingsFactory;
@@ -548,6 +549,13 @@ class Ray
         }
 
         return $this;
+    }
+
+    public function url(string $url, ?string $label = null): self
+    {
+        $payload = new UrlPayload($url, $label);
+
+        return $this->sendRequest($payload);
     }
 
     public function send(...$arguments): self

--- a/tests/RayTest.php
+++ b/tests/RayTest.php
@@ -1082,6 +1082,15 @@ class RayTest extends TestCase
         $this->assertCount(6, $this->client->sentPayloads());
     }
 
+    /** @test */
+    public function it_sends_url_payloads()
+    {
+        $this->getNewRay()->url('https://localhost:8000/test/1');
+        $this->getNewRay()->url('https://localhost:8000/test/2', 'Test Two');
+
+        $this->assertMatchesOsSafeSnapshot($this->client->sentPayloads());
+    }
+
     protected function getNewRay(): Ray
     {
         return Ray::create($this->client, 'fakeUuid');

--- a/tests/__snapshots__/RayTest__it_sends_url_payloads__1.json
+++ b/tests/__snapshots__/RayTest__it_sends_url_payloads__1.json
@@ -1,0 +1,38 @@
+[
+    {
+        "uuid": "fakeUuid",
+        "payloads": [
+            {
+                "type": "custom",
+                "content": {
+                    "content": "<a class=\"text-blue-600 underline\" href=\"https:\/\/localhost:8000\/test\/1\">https:\/\/localhost:8000\/test\/1<\/a>",
+                    "label": "URL"
+                },
+                "origin": {
+                    "file": "\/tests\/RayTest.php",
+                    "line_number": "xxx",
+                    "hostname": "fake-hostname"
+                }
+            }
+        ],
+        "meta": []
+    },
+    {
+        "uuid": "fakeUuid",
+        "payloads": [
+            {
+                "type": "custom",
+                "content": {
+                    "content": "<div class=\"pr-3 inline\">Test Two<\/div><a class=\"text-blue-600 underline\" href=\"https:\/\/localhost:8000\/test\/2\">https:\/\/localhost:8000\/test\/2<\/a>",
+                    "label": "URL"
+                },
+                "origin": {
+                    "file": "\/tests\/RayTest.php",
+                    "line_number": "xxx",
+                    "hostname": "fake-hostname"
+                }
+            }
+        ],
+        "meta": []
+    }
+]


### PR DESCRIPTION
This PR adds a new method to the `Ray` class, `url()`.

This method allows the developer to display a clickable link to a given URL within Ray, along with an optional label:

```php
ray()->url('https://localhost:8000/products');
ray()->url('https://localhost:8000/products/123', 'Product 123');
ray()->url('https://localhost:8000/products/456', 'Product 456');
```
![image](https://user-images.githubusercontent.com/5508707/123511333-a50fc780-d64e-11eb-90e4-d6661080c39c.png)

This method adds a convenient and intuitive way to display links within Ray.  As most projects using `spatie/ray` are web-based projects and therefore contain many URLs, the overall developer experience will be enhanced as a result of merging this PR.

This PR also includes unit tests and updated documentation.

_Note: If accepted, this method will be used in a future PR to [spatie/laravel-ray](https://github.com/spatie/laravel-ray)._