### PR TITLE
Add node-ray-cli docs

### DIFF
--- a/docs/configuration/bash.md
+++ b/docs/configuration/bash.md
@@ -1,0 +1,8 @@
+---
+title: Bash
+weight: 10
+---
+
+### Configuration
+
+For details on configuring `permafrost-dev/node-ray-cli`, see [NodeJS configuration](/docs/ray/v1/configuration/nodejs).

--- a/docs/installation-in-your-project/bash.md
+++ b/docs/installation-in-your-project/bash.md
@@ -3,6 +3,30 @@ title: Bash
 weight: 8
 ---
 
-You can send information from Bash to Ray via this third party package:
+You can send information from Bash to Ray via one of these third party packages:
+
+## node-ray-cli
+
+Install the package normally with `npm`:
+
+```bash
+npm install node-ray-cli
+```
+
+...install it globally to be able to access it from any script/directory:
+
+```bash
+npm install -g node-ray-cli
+```
+
+...or run it without installing using `npx`:
+
+```bash
+npx node-ray-cli --help
+```
+
+[permafrost-dev/node-ray-cli](https://github.com/permafrost-dev/node-ray-cli)
+
+## ray-cli 
 
 [permafrost-dev/ray-cli](https://github.com/permafrost-dev/ray-cli)

--- a/docs/usage/bash.md
+++ b/docs/usage/bash.md
@@ -1,0 +1,87 @@
+---
+title: Bash
+weight: 12
+---
+
+You can debug your CLI scripts with the `node-ray-cli` package or simply send data to Ray from the command line.
+
+### Running the application
+
+`ray <command name> <args, ...>`
+
+When calling commands that send modifiable payloads, the payload uuid is sent to stdout **if** the `--show-uuid` option flag is provided.  For example, you may modify the color of a payload after it has been sent by using the `color` command:
+
+```bash
+ray 'hello world' --show-uuid # writes "ae625128-ed3a-2b92-1a3f-2e0ebf7a2ad1" to stdout
+ray color ae625128-ed3a-2b92-1a3f-2e0ebf7a2ad1 green
+```
+
+...or remove the payload from Ray entirely:
+```bash
+ray 'hello world' --show-uuid # writes "ae625128-ed3a-2b92-1a3f-2e0ebf7a2ad1" to stdout
+ray remove ae625128-ed3a-2b92-1a3f-2e0ebf7a2ad1
+```
+
+Some other usage examples: 
+
+```bash
+ray 'hello world' --blue
+ray pause
+ray html '<em>hello world</em>'
+ray file message.txt
+```
+
+## Disabling node-ray-cli
+
+The `ray` command can be disabled by setting the `NODE_RAY_DISABLED` environment variable to `"1"`:
+
+```bash
+export NODE_RAY_DISABLED="1"
+```
+
+## Available option flags
+
+There are several option flags that can be used with any command:
+
+| Flag | Description |
+| --- | --- |
+| `--hide` | Display the payload as collapsed by default |
+| `--if=value` | Don't send the payload if `value` is `"false"`, `0`, or `"no"` |
+| `--large` | Display large text |
+| `--show-uuid` | Write the payload uuid to stdout |
+| `--small` | Display small text |
+| `--blue` | Display the payload as blue  |
+| `--gray` | Display the payload as gray  |
+| `--green` | Display the payload as green  |
+| `--orange` | Display the payload as orange  |
+| `--purple` | Display the payload as purple  |
+| `--red` | Display the payload as red  |
+
+## Example Bash Script
+
+```bash
+#!/bin/bash
+
+RAYUUID=$(ray "arg count: $#" --show-uuid)
+ray color $RAYUUID blue
+
+if [ $# -eq 0 ]; then
+    echo "no filename provided"
+    exit 1
+fi
+
+FILENAME="$1"
+
+ray "$FILENAME"
+ray file "$FILENAME" --purple --small --hide
+ray show-app
+
+if [ ! -e "$FILENAME" ]; then
+    ray send "file missing: $FILENAME" --red
+    exit 1
+fi
+
+ray pause
+
+cat "$FILENAME" | wc -l
+```

--- a/docs/usage/reference.md
+++ b/docs/usage/reference.md
@@ -23,6 +23,7 @@ To display something in Ray use the `ray()` function. It accepts everything: str
 - [Vue](#vue)
 - [Go](#go)
 - [Alpine.js](#alpinejs)
+- [Bash](#bash)
 
 ## Framework agnostic PHP
 
@@ -298,3 +299,27 @@ All methods available to [NodeJS](#nodejs) are available to the Alpine.js integr
 | `$ray.send()` | Update the content of a Ray instance  |
 
 Read more on [JavaScript](/docs/ray/v1/usage/javascript)
+
+## Bash
+
+| Command | Description |
+| --- | --- |
+| `clear` | Clear the current screen |
+| `clear-all` | Clear the current and all previous screens |
+| `color <uuid> <color>` | Change the color of a payload that has already been sent |
+| `file <filename>` | Show the contents of `filename` |
+| `hide-app` | Hide the Ray app |
+| `html <content>` | Display rendered html |
+| `image <location>` | Display an image from a URL or file |
+| `json <content>` | Display formatted JSON |
+| `notify <message>` | Display a desktop notification |
+| `pause` | Pause code execution |
+| `remove <uuid>` | Remove a payload |
+| `send <payload>` | Send a payload to Ray |
+| `show-app` | Show the Ray app |
+| `size <uuid> <size>` | Change the text size of a payload that has already been sent _(sizes are 'large' or 'small')_ |
+| `text <data>` | Display a text string with whitespace preserved |
+| `xml <data>` | Display formatted XML |
+
+Read more on [Bash](/docs/ray/v1/usage/bash)
+


### PR DESCRIPTION
This PR adds documentation for bash/cli debugging with [permafrost-dev/node-ray-cli](https://github.com/permafrost-dev/node-ray-cli).  It is based on the Ray integration package `node-ray`.

Specifically, it adds pages for:
- installation
- configuration
- usage
- command reference