### PR TITLE
Feature: base64-encoded image support

### DIFF
--- a/docs/usage/framework-agnostic-php-project.md
+++ b/docs/usage/framework-agnostic-php-project.md
@@ -361,11 +361,15 @@ ray()->table(['John', 'Paul', 'George', 'Ringo'], 'Beatles');
 
 ### Displaying images
 
-To display an image, call the `image` function and pass either a fully-qualified filename or url as its only argument.
+To display an image, call the `image` function and pass a fully-qualified filename, url, or a valid base64-encoded image as its only argument.
 
 ```php
 ray()->image('https://placekitten.com/200/300');
 ray()->image('/home/user/kitten.jpg');
+
+// display base64-encoded images
+ray()->image('data:image/png;base64,iVBORw0KGgoAAA...truncated');
+ray()->image('iVBORw0KGgoAAA...truncated');
 ```
 
 ### Rendering HTML

--- a/src/Payloads/ImagePayload.php
+++ b/src/Payloads/ImagePayload.php
@@ -2,6 +2,8 @@
 
 namespace Spatie\Ray\Payloads;
 
+use Illuminate\Support\Str;
+
 class ImagePayload extends Payload
 {
     /** @var string */
@@ -23,11 +25,32 @@ class ImagePayload extends Payload
             $this->location = 'file://' . $this->location;
         }
 
+        if ($this->hasBase64Data()) {
+            $this->location = $this->getLocationForBase64Data();
+        }
+
         $location = str_replace('"', '', $this->location);
 
         return [
             'content' => "<img src=\"{$location}\" alt=\"\" />",
             'label' => 'Image',
         ];
+    }
+
+    protected function stripDataPrefix(string $data): string
+    {
+        return preg_replace('~^data:image/[a-z]+;base64,~', '', $data);
+    }
+
+    protected function hasBase64Data(): bool
+    {
+        $data = $this->stripDataPrefix($this->location);
+
+        return base64_encode(base64_decode($data, true)) === $data;
+    }
+
+    protected function getLocationForBase64Data(): string
+    {
+        return 'data:image/png;base64,' . $this->stripDataPrefix($this->location);
     }
 }

--- a/tests/RayTest.php
+++ b/tests/RayTest.php
@@ -621,6 +621,15 @@ class RayTest extends TestCase
     }
 
     /** @test */
+    public function it_sends_a_base64_encoded_image_payload()
+    {
+        $this->ray->image('dGVzdCBzdHJpbmc=');
+        $this->ray->image('data:image/png;base64,dGVzdCBzdHJpbmc=');
+
+        $this->assertMatchesOsSafeSnapshot($this->client->sentPayloads());
+    }
+
+    /** @test */
     public function it_sends_a_table_payload()
     {
         $this->ray->table([

--- a/tests/__snapshots__/RayTest__it_sends_a_base64_encoded_image_payload__1.json
+++ b/tests/__snapshots__/RayTest__it_sends_a_base64_encoded_image_payload__1.json
@@ -1,0 +1,38 @@
+[
+    {
+        "uuid": "fakeUuid",
+        "payloads": [
+            {
+                "type": "custom",
+                "content": {
+                    "content": "<img src=\"data:image\/png;base64,dGVzdCBzdHJpbmc=\" alt=\"\" \/>",
+                    "label": "Image"
+                },
+                "origin": {
+                    "file": "\/tests\/RayTest.php",
+                    "line_number": "xxx",
+                    "hostname": "fake-hostname"
+                }
+            }
+        ],
+        "meta": []
+    },
+    {
+        "uuid": "fakeUuid",
+        "payloads": [
+            {
+                "type": "custom",
+                "content": {
+                    "content": "<img src=\"data:image\/png;base64,dGVzdCBzdHJpbmc=\" alt=\"\" \/>",
+                    "label": "Image"
+                },
+                "origin": {
+                    "file": "\/tests\/RayTest.php",
+                    "line_number": "xxx",
+                    "hostname": "fake-hostname"
+                }
+            }
+        ],
+        "meta": []
+    }
+]


### PR DESCRIPTION
This PR adds support for displaying images that are base64-encoded.  It adds the feature requested in #498.

Specifically, it adds support for strings prefixed with `data:image/<type>;base64,` and unprefixed base64 strings.  The strings are validated as correctly encoded base64 data.

```php
ray()->image('data:image/png;base64,iVBORw0KGgoAAA...truncated');
ray()->image('iVBORw0KGgoAAA...truncated');
```

![image](https://user-images.githubusercontent.com/5508707/124325830-5f259880-db53-11eb-96a3-402c1815c7ce.png)

This PR also includes updated documentation and unit tests.