### PR TITLE
Adjust PHP comments to be inside of PHP's tags for easy copy-and-paste

### DIFF
--- a/docs/configuration/craft-cms.md
+++ b/docs/configuration/craft-cms.md
@@ -6,8 +6,9 @@ weight: 7
 For Craft CMS projects you can create a `craft-ray.php` file in your project's `config` directory.
 
 ```php
-// save this in a file called "craft-ray.php" in the config directory of your project
 <?php
+// Save this in a file called "craft-ray.php" in the config directory of your project
+
 return [
     /*
     * This settings controls whether data should be sent to Ray.

--- a/docs/configuration/framework-agnostic-php.md
+++ b/docs/configuration/framework-agnostic-php.md
@@ -6,8 +6,9 @@ weight: 2
 In framework agnostic projects you can use this template as [the ray config file](/docs/ray/v1/configuration/general).
 
 ```php
-// save this in a file called "ray.php"
 <?php
+// Save this in a file called "ray.php"
+
 return [
     /*
     * This settings controls whether data should be sent to Ray.

--- a/docs/configuration/laravel.md
+++ b/docs/configuration/laravel.md
@@ -8,8 +8,9 @@ For Laravel projects you can create a `ray.php` file in your project directory (
 Note: if everyone working on the project needs the same configuration, you can put the file in the `config` directory as well.
 
 ```php
-// save this in a file called "ray.php" in the root directory of your project; not in the Laravel "config" directory
 <?php
+// Save this in a file called "ray.php" in the root directory of your project; not in the Laravel "config" directory
+
 return [
     /*
     * This settings controls whether data should be sent to Ray.

--- a/docs/configuration/nodejs.md
+++ b/docs/configuration/nodejs.md
@@ -9,7 +9,7 @@ In NodeJS based projects, you can optionally create a `ray.config.js` file in yo
 You can use this template as [the ray config file](/docs/ray/v1/configuration/nodejs):
 
 ```js
-// save this in a file named "ray.config.js"
+// Save this in a file named "ray.config.js"
 module.exports = {
     /*
     * This settings controls whether data should be sent to Ray.

--- a/docs/configuration/wordpress.md
+++ b/docs/configuration/wordpress.md
@@ -6,8 +6,9 @@ weight: 4
 In WordPress apps you can use this template as [the ray config file](/docs/ray/v1/configuration/general).
 
 ```php
-// save this in a file called "ray.php"
 <?php
+// Save this in a file called "ray.php"
+
 return [
     /*
     * This settings controls whether data should be sent to Ray.

--- a/docs/configuration/yii2.md
+++ b/docs/configuration/yii2.md
@@ -6,8 +6,9 @@ weight: 6
 For Yii projects you can create a `ray.php` file in your project's `config` directory.
 
 ```php
-// save this in a file called "ray.php" in the config directory of your project
 <?php
+// Save this in a file called "ray.php" in the config directory of your project
+
 return [
     /*
     * This settings controls whether data should be sent to Ray.


### PR DESCRIPTION
As with https://github.com/spatie/ray/pull/502, I noticed there were some other docs I forgot to update to reflect the same adjustment for easy copy-and-paste of the documented configs.

Thanks for the great software!