### PR TITLE
Clear screen before displaying data

### DIFF
--- a/docs/usage/framework-agnostic-php-project.md
+++ b/docs/usage/framework-agnostic-php-project.md
@@ -80,6 +80,14 @@ To clear the current screen and all previous screens, call `clearAll`.
 ray()->clearAll(); 
 ```
 
+### Clearing screen before displaying payload
+
+To clear the current screen just before displaying new data, call `clearScreenBefore`.
+
+```php
+ray()->clearScreenBefore('your', 'data'); 
+```
+
 ### See the caller of a function
 
 Sometimes you want to know where your code is being called. You can quickly determine that by using the `caller`

--- a/src/Ray.php
+++ b/src/Ray.php
@@ -158,6 +158,11 @@ class Ray
         return $this->newScreen();
     }
 
+    public function clearScreenBefore(...$args): self
+    {
+        return $this->clearScreen()->send(...$args);
+    }
+
     public function color(string $color): self
     {
         $payload = new ColorPayload($color);

--- a/tests/RayTest.php
+++ b/tests/RayTest.php
@@ -412,6 +412,16 @@ class RayTest extends TestCase
     }
 
     /** @test */
+    public function it_can_clear_screen_before_send_payload()
+    {
+        $data = ['a' => 1, 'b' => 2];
+
+        $this->ray->clearScreenBefore($data);
+
+        $this->assertMatchesOsSafeSnapshot($this->client->sentPayloads());
+    }
+
+    /** @test */
     public function it_can_send_the_clear_all_payload()
     {
         $this->ray->clearAll();


### PR DESCRIPTION
Hi all!
This PR adds a new method to the Ray - `clearScreenBefore()`.

```php
ray()->clearScreenBefore('some', 'data');
```

This method clear screen just before displaying new data. 

This is faster than typing:

```php
ray()->clearScreen();
ray('some', 'data');
```

This PR contains new method, dosc update and test,
Greetings
