### PR TITLE
You need another step to make tis work on MacOS with Docker

### DIFF
--- a/docs/environment-specific-configuration/docker.md
+++ b/docs/environment-specific-configuration/docker.md
@@ -44,6 +44,8 @@ Then `remote_path` should be `/var/www` and `local_path` should be the absolute 
 mount as `/var/www`, which is where your `docker-compose.yml` is located in the example (you can find this by 
 running `pwd` inside that directoy if you are on Linux).
 
+Add `127.0.0.1 	host.docker.internal` to `/etc/hosts`file.
+
 On Linux, you will also need to add an 'extra_hosts' parameter to your PHP container definitions to expose 'host.docker.internal'. Please make sure you are using Docker `20.03` or higher.
 ```
 #docker-compose.yml


### PR DESCRIPTION
I only got the links working after changing the hosts file.
The tip came from this page: https://dev.to/stuartcreed/how-to-make-spatie-ray-work-with-laravel-sail-992