### PR TITLE
Add function to clear the rate limiter

### DIFF
--- a/src/Ray.php
+++ b/src/Ray.php
@@ -159,6 +159,12 @@ class Ray
         return $this->newScreen();
     }
 
+    public function clearRateLimiter(): self
+    {
+        self::rateLimiter()->clear();
+        return $this;
+    }
+
     public function color(string $color): self
     {
         $payload = new ColorPayload($color);


### PR DESCRIPTION
Problem:
When Ray is enabled in laravel, calls to dump(); will increase memory usage consider the following:
```
Artisan::command('ray', function () {
    while (true) {
        $usage = round(memory_get_usage() / 1048576, 2);
        dump($usage);
        gc_collect_cycles();
    }
});
```

In this case the memory will start to increase with no bounds. At first I thought perhaps `ray()->clearAll()` would handle the clearing of the rate limiter, but it does not.

Cause:
`self::rateLimiter()->hit();` is called in during the dump command which adds to `$this->store[] = $this->clock->now();`


Solution:
Add a function to clear the rate limiter which can be called as such:  `ray()->clearRateLimiter();`
Looking at the modified example of the problem:
```
Artisan::command('ray', function () {
    while (true) {
        $usage = round(memory_get_usage() / 1048576, 2);
        dump($usage);
        ray()->clearRateLimiter();
        gc_collect_cycles();
    }
});
```

Now memory stays stable and does not increase as more dump()'s are called. I Would also suggest that `ray()->clearAll()` should also take care of this but I will await for a response on this Pull Request.