### PR TITLE
Add docs note to explain how to reach docker on a remote server

### DIFF
--- a/docs/the-ray-desktop-app/discovering-the-ray-app.md
+++ b/docs/the-ray-desktop-app/discovering-the-ray-app.md
@@ -61,5 +61,4 @@ The output of any `ray` calls on the remote server will now be shown.
 
 ![screenshot](/docs/ray/v1/images/remote-log.png)
 
-
-
+**Note:** if you are connecting to a docker container in a remote server (see [docker configuration](/docs/ray/v1/environment-specific-configuration/docker)), you may need to enable `GatewayPorts yes` in server's `/etc/ssh/sshd_config` configuration (remember to restart the sshd daemon in order to apply your changes).


### PR DESCRIPTION
This PR will add a small note in `Discovering the Ray app → Connecting to remote servers` in order to advice to enable `GatewayPorts yes` configuration for remote server docker connections

see: https://github.com/spatie/ray/discussions/550

@freekmurze, I was unsure if this should go in  `Discovering the Ray app`  or  `Environment Specific Configuration → Docker section`. I've put it where I first looked for when I faced this issue (reached Discovering the Ray app through Environment Specific Configuration → Remote Servers), feel free to ask and I'll move it to the other section (or, maybe, a brief reference should be put there?)