### PR TITLE
🚀 Support PHP 8.1

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -9,7 +9,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest]
-        php: [8.0, 7.4, 7.3]
+        php: [8.1, 8.0, 7.4, 7.3]
         dependency-version: [prefer-lowest, prefer-stable]
 
     name: P${{ matrix.php }} - ${{ matrix.dependency-version }} - ${{ matrix.os }}
@@ -24,6 +24,10 @@ jobs:
           php-version: ${{ matrix.php }}
           extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite, bcmath, soap, intl, gd, exif, iconv, imagick
           coverage: none
+
+      - name: Configure for PHP 8.1
+        run: composer config platform.php 8.0.99
+        if: matrix.php == '8.1'
 
       - name: Setup Problem Matches
         run: |

--- a/src/Payloads/FileContentsPayload.php
+++ b/src/Payloads/FileContentsPayload.php
@@ -36,9 +36,9 @@ class FileContentsPayload extends Payload
 
     protected function encodeContent(string $content): string
     {
-        $result = htmlentities($content);
+        $result = htmlentities($content, ENT_QUOTES | ENT_SUBSTITUTE);
 
-        // using nl2br() causes tests to fail on windows, so use <br> only
+        // using nl2br() causes tests to fail on Windows, so use <br> only
         return str_replace(PHP_EOL, '<br />', $result);
     }
 }

--- a/tests/__snapshots__/RayTest__it_can_send_the_file_content_payload__1.json
+++ b/tests/__snapshots__/RayTest__it_can_send_the_file_content_payload__1.json
@@ -5,7 +5,7 @@
             {
                 "type": "custom",
                 "content": {
-                    "content": "&lt;?php<br \/><br \/>return [<br \/>    'port' =&gt; 12345,<br \/><br \/>    'host' =&gt; 'http:\/\/otherhost',<br \/>];<br \/>",
+                    "content": "&lt;?php<br \/><br \/>return [<br \/>    &#039;port&#039; =&gt; 12345,<br \/><br \/>    &#039;host&#039; =&gt; &#039;http:\/\/otherhost&#039;,<br \/>];<br \/>",
                     "label": "ray.php"
                 },
                 "origin": {


### PR DESCRIPTION
Changes
- Encode `'` to `&#039;`
Prior to PHP 8.1, the default behaviour of htmlentities() is to not convert single quotes (') to HTML entities. In 8.1 this is the default.