### PR TITLE
Add context to ApplicationLog

### DIFF
--- a/src/Payloads/ApplicationLogPayload.php
+++ b/src/Payloads/ApplicationLogPayload.php
@@ -6,10 +6,14 @@ class ApplicationLogPayload extends Payload
 {
     /** @var string */
     protected $value;
+    
+    /** @var array */
+    protected $context;
 
-    public function __construct(string $value)
+    public function __construct(string $value, array $context = [])
     {
         $this->value = $value;
+        $this->context = $context;
     }
 
     public function getType(): string
@@ -21,6 +25,7 @@ class ApplicationLogPayload extends Payload
     {
         return [
             'value' => $this->value,
+            'context' => $this->context,
         ];
     }
 }


### PR DESCRIPTION
When logging, there can sometimes be additional context in the the log that would be useful to display in Ray.

This doesn't implement anything other than adding an additional argument to the constructor; the formatting will need to be implemented in the server. Additionally, the watcher in the Laravel package (and I presume the rest of the framework-specific packages) will need to be updated to pass in the context from the message object:

laravel/ray Spatie\LaravelRay\Watchers/ApplicationLogWatcher:24
`$payload = new ApplicationLogPayload($message->message, $message->context);`

This PR is relatively useless as the real work is done on the server-side, just putting it out there as the first step to implementing #257.