### PR TITLE
Point to "servers" instead of singular "server"

### DIFF
--- a/docs/environment-specific-configuration/remote-servers.md
+++ b/docs/environment-specific-configuration/remote-servers.md
@@ -5,5 +5,5 @@ weight: 5
 
 Ray can display the output of any `ray` calls on remote servers. 
 
-Learn more in the section on [using the Ray app to connected to remote servers](https://spatie.be/docs/ray/v1/the-ray-desktop-app/discovering-the-ray-app#connecting-to-remote-server).
+Learn more in the section on [using the Ray app to connected to remote servers](https://spatie.be/docs/ray/v1/the-ray-desktop-app/discovering-the-ray-app#connecting-to-remote-servers).
 


### PR DESCRIPTION
Fix typo in documentation