### PR TITLE
Add documentation for showing slow queries in Laravel

### DIFF
--- a/docs/usage/laravel.md
+++ b/docs/usage/laravel.md
@@ -122,6 +122,17 @@ ray()->showSlowQueries(100);
 User::firstWhere('email', 'john@example.com');
 ```
 
+Alternatively, you can also pass a callable to `showSlowQueries`. Only the slow queries performed inside that callable will be displayed in Ray.
+
+```php
+User::all();
+User::all(); // this query won't be displayed.
+
+ray()->showSlowQueries(100, function() {
+    User::where('id', 1)->get('id'); // this query will be displayed if it takes longer than 100ms.
+});
+```
+
 You can also use the shorthand method, `slowQueries()`:
 
 ```php

--- a/docs/usage/laravel.md
+++ b/docs/usage/laravel.md
@@ -111,6 +111,25 @@ User::all();
 User::all(); // this query won't be displayed.
 ```
 
+### Showing slow queries
+
+You can display all queries that took longer than a specified number of milliseconds to execute by calling `showSlowQueries`.
+
+```php
+ray()->showSlowQueries(100);
+
+// this query will only be displayed in Ray if it takes longer than 100ms to execute.
+User::firstWhere('email', 'john@example.com');
+```
+
+You can also use the shorthand method, `slowQueries()`:
+
+```php
+ray()->slowQueries(); // equivalent to calling 'showSlowQueries'.
+```
+
+To stop showing slow queries, call `stopShowingSlowQueries`.
+
 ### Showing events
 
 You can display all events that are executed by calling `showEvents` (or `events`).

--- a/docs/usage/reference.md
+++ b/docs/usage/reference.md
@@ -116,8 +116,11 @@ Read more on [Framework agnostic PHP](/docs/ray/v1/usage/framework-agnostic-php-
 | `ray()->stopShowingJobs()` | Stop displaying jobs  |
 | `ray()->showQueries()` | Display all queries that are executed  |
 | `ray()->showQueries(callable)` | Display all queries that are executed within a callable |
+| `ray()->slowQueries(N)` | Display all queries that take longer than N milliseconds to execute |
+| `ray()->showSlowQueries(N)` | Display all queries that take longer than N milliseconds to execute |
 | `ray()->countQueries(callable)` | Count all queries that are executed within a callable |
 | `ray()->stopShowingQueries()` | Stop displaying queries  |
+| `ray()->stopShowingSlowQueries()` | Stop displaying queries  |
 | `ray()->showRequests()` | Display all requests  |
 | `ray()->stopShowingRequests()` | Stop displaying requests  |
 | `ray()->showViews()` | Display all views  |


### PR DESCRIPTION
This PR adds documentation for the [recently added feature](https://github.com/spatie/laravel-ray/pull/232) to `spatie/laravel-ray` that displays "slow" queries (queries that take longer than N milliseconds to execute).