### PR TITLE
Ignore docs folder on package install

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -6,6 +6,7 @@
 /.gitignore         export-ignore
 /phpunit.xml.dist   export-ignore
 /tests              export-ignore
+/docs               export-ignore
 /.editorconfig      export-ignore
 /.php_cs            export-ignore
 /.github            export-ignore


### PR DESCRIPTION
While debugging the size of my vendor folder, I noticed that the `docs` folder of ray is 8.7M big.
I would also ignore the `docs` folder, as you do it for other files/folders.