### PR TITLE
Implement ray()->iterateOver(iterable, int), fixes #628

### DIFF
--- a/src/Ray.php
+++ b/src/Ray.php
@@ -322,7 +322,7 @@ class Ray
     {
         $count = 0;
         $items = [];
-        foreach($iterable as $item) {
+        foreach ($iterable as $item) {
             if ($count >= $max) {
                 break;
             }
@@ -331,10 +331,10 @@ class Ray
 
             $count++;
         }
-        
+
         $payloads = PayloadFactory::createForValues($items);
 
-        return $this->sendRequest($payloads);        
+        return $this->sendRequest($payloads);
     }
 
     public function notify(string $text): self

--- a/src/Ray.php
+++ b/src/Ray.php
@@ -318,10 +318,6 @@ class Ray
         return $this;
     }
 
-    /**
-     * Iterates over the iterator and sends the first $max values
-     */
-
     public function iterateOver(iterable $iterable, int $max = 10)
     {
         $count = 0;

--- a/src/Ray.php
+++ b/src/Ray.php
@@ -318,6 +318,29 @@ class Ray
         return $this;
     }
 
+    /**
+     * Iterates over the iterator and sends the first $max values
+     */
+
+    public function iterateOver(iterable $iterable, int $max = 10)
+    {
+        $count = 0;
+        $items = [];
+        foreach($iterable as $item) {
+            if ($count >= $max) {
+                break;
+            }
+
+            $items[] = $item;
+
+            $count++;
+        }
+        
+        $payloads = PayloadFactory::createForValues($items);
+
+        return $this->sendRequest($payloads);        
+    }
+
     public function notify(string $text): self
     {
         $payload = new NotifyPayload($text);

--- a/tests/RayTest.php
+++ b/tests/RayTest.php
@@ -347,7 +347,7 @@ class RayTest extends TestCase
     /** @test */
     public function it_can_iterate_over_an_iterable()
     {
-        $iterable = range(1,5);
+        $iterable = range(1, 5);
 
         $this->ray->iterateOver($iterable);
         $this->assertCount(5, $this->client->sentPayloads()[0]['payloads']);

--- a/tests/RayTest.php
+++ b/tests/RayTest.php
@@ -345,6 +345,20 @@ class RayTest extends TestCase
     }
 
     /** @test */
+    public function it_can_iterate_over_an_iterable()
+    {
+        $iterable = range(1,5);
+
+        $this->ray->iterateOver($iterable);
+        $this->assertCount(5, $this->client->sentPayloads()[0]['payloads']);
+
+        $this->client->reset();
+
+        $this->ray->iterateOver($iterable, 2);
+        $this->assertCount(2, $this->client->sentPayloads()[0]['payloads']);
+    }
+
+    /** @test */
     public function it_can_send_the_notify_payload()
     {
         $this->ray->notify('notification text');


### PR DESCRIPTION
Implemented `ray()->iterateOver(iterable $iterable, int $max = 10)` as suggested in #628.

I'm not sure if the tests are done the best way, testing `->sentPayloads()[0]['payloads']`, since in all other tests where it does an `assertCount` it justs tests directly on `sentPayloads`, but with how it looked to me my tests seem to test for the right thing.