### PR TITLE
Return false if success variable not defined

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -57,7 +57,7 @@ class Client
         } finally {
             curl_close($curlHandle);
 
-            return $success;
+            return $success ?? false;
         }
     }
 


### PR DESCRIPTION
On occasion, within our Laravel test suite, we'll get random errors with Ray when a request cannot be completed. All that shows is a failure because the `$success` variable is not defined.

```
ErrorException : Undefined variable $success
 /project/vendor/spatie/ray/src/Client.php:60
 /project/vendor/spatie/ray/src/Client.php:39
 /project/vendor/spatie/ray/src/Client.php:66
...
```

After implementing this change locally, the underlying failure was able to bubble up as expected.