### PR TITLE
Add docs for express.js integration

### DIFF
--- a/docs/installation-in-your-project/expressjs.md
+++ b/docs/installation-in-your-project/expressjs.md
@@ -1,0 +1,30 @@
+---
+title: Express.js
+weight: 12
+---
+
+You can send information from Express.js applications to Ray via this third party package:
+
+[permafrost-dev/express-ray](https://github.com/permafrost-dev/express-ray)
+
+### Installing the package
+
+You can install this third-party package using either `npm` or `yarn`:
+
+```bash
+npm install express-ray
+
+yarn add express-ray
+```
+
+### Installing the plugin
+
+To install the `express-ray` plugin into your Express.js application, call the `install` method provided by the `plugin` import:
+
+```js
+import { plugin as expressRayPlugin } from 'express-ray';
+
+const app = express();
+
+expressRayPlugin.install(app);
+```

--- a/docs/usage/expressjs.md
+++ b/docs/usage/expressjs.md
@@ -1,0 +1,63 @@
+---
+title: Express.js
+weight: 12
+---
+
+The third-party [Express.js package](https://github.com/permafrost-dev/express-ray) for Ray uses the [package for NodeJS](/docs/ray/v1/installation-in-your-project/nodejs) for 
+most core functionality. See the [NodeJS reference](/docs/ray/v1/usage/nodejs) for a full list of available methods.
+
+Once the plugin is installed, you may access the helper function as `app.$ray()` from within your Express application.
+
+
+```js
+app.get('/', (req, res) => {
+    app.$ray('sending "hello world" response');
+    res.send('hello world');
+});
+```
+
+### SendRequestToRay Middleware
+
+Send details about each request to Ray with the `SendRequestToRay` middleware, optionally specifying configuration settings.
+
+```ts
+interface SendRequestToRayOptions {
+    paths?: {
+        include?: string[];
+        ignore?: string[];
+    }
+}
+```
+
+By default, all paths match and get sent to Ray. Both the `paths.include` and `paths.ignore` configuration settings support wildcards.
+
+```js
+import { middleware } from 'express-ray';
+
+app.use(
+    middleware.SendRequestToRay({ paths: { include: ['*'], ignore: ['*.css'] } })
+);
+```
+
+All configuration settings for this middleware are optional:
+
+```js
+app.use(middleware.SendRequestToRay());
+```
+
+### SendErrorToRay Middleware
+
+To send errors directly to Ray, use the `SendErrorToRay` middleware.
+
+```js
+import { middleware } from 'express-ray';
+
+// <express setup code here>
+
+// register the middleware just before listen()
+app.use(middleware.SendErrorToRay);
+
+app.listen(port, () => {
+    console.log(`Listening on port ${port}`);
+});
+```


### PR DESCRIPTION
This PR adds documentation for the [express.js integration package](https://github.com/permafrost-dev/express-ray).

The package allows requests and errors to be automatically sent to Ray for easy debugging, along with direct access to `$ray()` for sending arbitrary data.

![image](https://user-images.githubusercontent.com/5508707/158339805-52da23bd-85cd-4281-baea-96658777a0fa.png)
