### PR TITLE
Update SettingsFactory.php

### DIFF
--- a/src/Settings/SettingsFactory.php
+++ b/src/Settings/SettingsFactory.php
@@ -49,7 +49,7 @@ class SettingsFactory
 
         $configDirectory = $configDirectory ?? getcwd();
 
-        if ($configDirectory == '/') {
+        if (($configDirectory == '/') || str_contains($configDirectory,'/cgi-bin/')) {
             return '';
         }
 

--- a/src/Settings/SettingsFactory.php
+++ b/src/Settings/SettingsFactory.php
@@ -49,7 +49,7 @@ class SettingsFactory
 
         $configDirectory = $configDirectory ?? getcwd();
 
-        if (($configDirectory == '/') || str_contains($configDirectory,'/cgi-bin/')) {
+        if (($configDirectory == '/') || (strpos($configDirectory,'/cgi-bin/') !== false)) {
             return '';
         }
 

--- a/src/Settings/SettingsFactory.php
+++ b/src/Settings/SettingsFactory.php
@@ -49,6 +49,10 @@ class SettingsFactory
 
         $configDirectory = $configDirectory ?? getcwd();
 
+        if ($configDirectory == '/') {
+            return '';
+        }
+
         while (@is_dir($configDirectory)) {
             foreach ($configNames as $configName) {
                 $configFullPath = $configDirectory.DIRECTORY_SEPARATOR.$configName;


### PR DESCRIPTION
The bug described in https://github.com/spatie/ray/issues/73 is still present in Ray. 
When code is run _on shutdown_, the result of getcwd() is `/`. (see [this comment on php.net](https://www.php.net/manual/en/function.getcwd.php#43451))

 So when you run this:
```php
register_shutdown_function(function () {
    ray('hello world');
});
```
the method `searchConfigFilesOnDisk()` will start searching in `/` triggering an unwanted `'is_dir(): open_basedir restriction in effect` E_WARNING

This pull request will fix this by stop searching any further when the path is `/`
