### PR TITLE
Added a verification that the Yii class exists

### DIFF
--- a/src/helpers.php
+++ b/src/helpers.php
@@ -28,11 +28,11 @@ if (! function_exists('ray')) {
             }
         }
 
-        if (class_exists(CraftRay::class)) {
+        if (class_exists(CraftRay::class) && class_exists(Yii::class)) {
             return Yii::$container->get(CraftRay::class)->send(...$args);
         }
 
-        if (class_exists(YiiRay::class)) {
+        if (class_exists(YiiRay::class) && class_exists(Yii::class)) {
             return Yii::$container->get(YiiRay::class)->send(...$args);
         }
 


### PR DESCRIPTION
When trying to use Laravel Envoy in a CraftCMS project got me this error:

`PHP Fatal error:  Uncaught Error: Class "Yii" not found in /.../vendor/spatie/ray/src/helpers.php:32`
