### PR TITLE
Revert version of spatie/macroable to ^1.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "ext-json": "*",
         "ramsey/uuid": "^3.0|^4.1",
         "spatie/backtrace": "^1.1",
-        "spatie/macroable": "^1.0|^2.0",
+        "spatie/macroable": "^1.0",
         "symfony/stopwatch": "^4.0|^5.1|^6.0",
         "symfony/var-dumper": "^4.2|^5.1|^6.0"
     },


### PR DESCRIPTION
This is because [`spatie/macroable`](https://github.com/spatie/macroable) ^2.0 is only compatible with PHP ^8.0, but [`spatie/ray`](https://github.com/spatie/ray) is supposed to support PHP ^7.4|^8.0.

The issue is the following line in `spatie/macroable`: https://github.com/spatie/macroable/blob/main/src/Macroable.php#L14. It uses the pipe operator in the method signature, which PHP ^7.4 doesn't understand, hence the error.

Here's the error:

```php
Fatal error: During class fetch: Uncaught ParseError: syntax error, unexpected '|', expecting variable (T_VARIABLE) in .../vendor/spatie/macroable/src/Macroable.php:14
```

Hopefully it's ok to revert this, but I understand if it's not viable!

Thanks for the time and effort you've put into the Ray plugin. I've found it tremendously helpful over the last year!