### PR TITLE
Bug/702 long integers

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -6,11 +6,6 @@ parameters:
 			path: src/Ray.php
 
 		-
-			message: "#^Access to static property \\$container on an unknown class Yii\\.$#"
-			count: 2
-			path: src/helpers.php
-
-		-
 			message: "#^Function app not found\\.$#"
 			count: 1
 			path: src/helpers.php

--- a/src/Payloads/LogPayload.php
+++ b/src/Payloads/LogPayload.php
@@ -21,6 +21,10 @@ class LogPayload extends Payload
     public function __construct($values)
     {
         if (! is_array($values)) {
+            if (is_int($values) && $values >= 11111111111111111) {
+                $values = (string) $values;
+            }
+
             $values = [$values];
         }
 

--- a/tests/RayTest.php
+++ b/tests/RayTest.php
@@ -1330,6 +1330,16 @@ class RayTest extends TestCase
         $this->assertEquals('my project', $this->client->sentRequests()[0]['meta']['project_name']);
     }
 
+    /** @test */
+    public function it_can_dump_long_integers_as_string()
+    {
+        $this->ray->send(11111111111111110);
+        $this->ray->send(11111111111111111);
+
+        $this->assertSame([11111111111111110], $this->client->sentRequests()[0]['payloads'][0]['content']['values']);
+        $this->assertSame(["11111111111111111"], $this->client->sentRequests()[1]['payloads'][0]['content']['values']);
+    }
+
     public function assertMatchesOsSafeSnapshot($data)
     {
         $this->assertMatchesJsonSnapshot(json_encode($data));


### PR DESCRIPTION
Not sure what the tipping point is, but large integers are not printed correctly in the Ray app. If anyone knows an alternative fix in the Ray app, this might be better, but for now we could send large integers as string.

**Before**
<img width="597" alt="Screenshot 2022-06-03 at 14 09 16" src="https://user-images.githubusercontent.com/10651054/171850804-9418d24c-ec49-45a7-9364-13e011754cfd.png">

**After**
<img width="520" alt="Screenshot 2022-06-03 at 14 09 35" src="https://user-images.githubusercontent.com/10651054/171850817-b1ea4421-23af-404f-82b7-f5eef16c8102.png">

Closes #702 