### PR TITLE
Added createFromArray method on SettingsFactory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to `ray` will be documented in this file
 
+## Unreleased
+### Added
+- Added a `createFromArray()` method on the `SettingsFactory`.
+
 ## 1.34.5 - 2022-06-03
 
 ### What's Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,6 @@
 
 All notable changes to `ray` will be documented in this file
 
-## Unreleased
-### Added
-- Added a `createFromArray()` method on the `SettingsFactory`.
-
 ## 1.34.5 - 2022-06-03
 
 ### What's Changed

--- a/src/Settings/SettingsFactory.php
+++ b/src/Settings/SettingsFactory.php
@@ -6,11 +6,16 @@ class SettingsFactory
 {
     public static $cache = [];
 
+    public static function createFromArray(array $settings = []): Settings
+    {
+        return new Settings($settings);
+    }
+
     public static function createFromConfigFile(string $configDirectory = null): Settings
     {
         $settingValues = (new static())->getSettingsFromConfigFile($configDirectory);
 
-        $settings = new Settings($settingValues);
+        $settings = static::createFromArray($settingValues);
 
         if (count($settingValues)) {
             $settings->markAsLoadedUsingSettingsFile();

--- a/tests/SettingsTest.php
+++ b/tests/SettingsTest.php
@@ -44,6 +44,15 @@ class SettingsTest extends TestCase
         $this->assertEquals('http://otherhost', $settings2->host);
     }
 
+    /** @test */
+    public function it_can_create_settings_from_an_Array()
+    {
+        $settings = SettingsFactory::createFromArray(['enabled' => false, 'port' => 1234]);
+
+        self::assertFalse($settings->enabled);
+        self::assertSame(1234, $settings->port);
+    }
+
     protected function skipOnGitHubActions(): void
     {
         if (getenv('CI')) {

--- a/tests/SettingsTest.php
+++ b/tests/SettingsTest.php
@@ -45,7 +45,7 @@ class SettingsTest extends TestCase
     }
 
     /** @test */
-    public function it_can_create_settings_from_an_Array()
+    public function it_can_create_settings_from_an_array()
     {
         $settings = SettingsFactory::createFromArray(['enabled' => false, 'port' => 1234]);
 


### PR DESCRIPTION
For the `symfony-ray` bundle I'm creating, I needed a settings factory method that accepts the configuration as an array; so I can use the normal Symfony configuration way. 

Instead of creating another simple factory class, I figure I'd add it to the original factory class.