### PR TITLE
Add PHP 8.2 support to tests workflow

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -34,6 +34,10 @@ jobs:
           echo "::add-matcher::${{ runner.tool_cache }}/php.json"
           echo "::add-matcher::${{ runner.tool_cache }}/phpunit.json"
 
+      - name: Configure for PHP 8.2
+        run: composer require "illuminate/support:8.*" --no-interaction --no-update
+        if: matrix.php == '8.2' && matrix.dependency-version == 'prefer-lowest'
+
       - name: Install dependencies
         run: composer update --${{ matrix.dependency-version }} --prefer-dist --no-interaction
 

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -9,14 +9,14 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest]
-        php: [8.1, 8.0, 7.4, 7.3]
+        php: [8.2, 8.1, 8.0, 7.4, 7.3]
         dependency-version: [prefer-lowest, prefer-stable]
 
     name: P${{ matrix.php }} - ${{ matrix.dependency-version }} - ${{ matrix.os }}
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -22,7 +22,7 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php }}
-          extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite, bcmath, soap, intl, gd, exif, iconv, imagick
+          extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite, bcmath, soap, intl, gd, exif, iconv, imagick, fileinfo
           coverage: none
 
       - name: Configure for PHP 8.1
@@ -35,7 +35,7 @@ jobs:
           echo "::add-matcher::${{ runner.tool_cache }}/phpunit.json"
 
       - name: Configure for PHP 8.2
-        run: composer require "illuminate/support:8.*" --no-interaction --no-update
+        run: composer require "illuminate/support:9.*" "nesbot/carbon:^2.63" --no-interaction --no-update
         if: matrix.php == '8.2' && matrix.dependency-version == 'prefer-lowest'
 
       - name: Install dependencies

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -35,7 +35,7 @@ jobs:
           echo "::add-matcher::${{ runner.tool_cache }}/phpunit.json"
 
       - name: Configure for PHP 8.2
-        run: composer require "illuminate/support:8.*" "nesbot/carbon:^2.63" --no-interaction --no-update
+        run: composer require "illuminate/support:8.*" --no-interaction --no-update
         if: matrix.php == '8.2' && matrix.dependency-version == 'prefer-lowest'
 
       - name: Install dependencies

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -35,7 +35,7 @@ jobs:
           echo "::add-matcher::${{ runner.tool_cache }}/phpunit.json"
 
       - name: Configure for PHP 8.2
-        run: composer require "illuminate/support:9.*" "nesbot/carbon:^2.63" --no-interaction --no-update
+        run: composer require "illuminate/support:8.*" "nesbot/carbon:^2.63" --no-interaction --no-update
         if: matrix.php == '8.2' && matrix.dependency-version == 'prefer-lowest'
 
       - name: Install dependencies

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
     },
     "require-dev": {
         "illuminate/support": "6.x|^8.18|^9.0",
-        "nesbot/carbon": "^2.43",
+        "nesbot/carbon": "^2.63",
         "pestphp/pest": "^1.22",
         "phpstan/phpstan": "^0.12.92",
         "phpunit/phpunit": "^9.5",


### PR DESCRIPTION
This PR adds PHP 8.2 to the tests workflow and bumps the `checkout` action version to v3.

It also bumps the minimum version of `nesbot/carbon` to allow for PHP 8.2 support.