### PR TITLE
Add docs for react-ray integration

### DIFF
--- a/docs/installation-in-your-project/react.md
+++ b/docs/installation-in-your-project/react.md
@@ -1,0 +1,18 @@
+---
+title: React
+weight: 8
+---
+
+You can send information from React (v16+) code to Ray via this third party package:
+
+[permafrost-dev/react-ray](https://github.com/permafrost-dev/react-ray)
+
+### Installing the package
+
+You can install this third-party package using either `npm` or `yarn`:
+
+```bash
+npm install react-ray
+
+yarn add react-ray
+```

--- a/docs/usage/react.md
+++ b/docs/usage/react.md
@@ -1,0 +1,85 @@
+---
+title: React
+weight: 8
+---
+
+The third-party React package for Ray, `react-ray`, uses the [package for NodeJS](/docs/ray/v1/installation-in-your-project/nodejs) for most core functionality.
+
+`react-ray` supports React 16+ and provides two hooks:
+
+- `useRay` - send data to the Ray app whenever it updates.
+- `useRayWithElement` - send the contents of an element ref to the Ray app, optionally updating the item in place when its dependencies change.
+
+### `useRay()`
+
+To send data to Ray whenever it updates, use the `useRay` hook along with the `type` option to specify the type of data you are sending.  
+The `boolean` `replace` option can be used to update the Ray item in place when its dependencies change.  The default value for `replace` is `false`.
+
+Valid types are `image`, `json`, `html`, `text`, or `xml`. See the [`node-ray` documentation](https://github.com/permafrost-dev/node-ray) for more information on these types.
+
+```js
+import { useRay } from 'react-ray';
+import { useEffect, useState } from 'react';
+
+const MyComponent = () => {
+    const [count, setCount] = useState(0);
+
+    useRay(count, { type: 'text', replace: true });
+
+    return (
+        <button onClick={() => setCount(count + 1)}>
+            Click me
+        </button>
+    );
+};
+```
+
+### `useRayWithElement()`
+
+To send the contents of a ref to the Ray app in a sequential manner (each dependency change sends a new item), set the `replace` option to `false`:
+
+```js
+import { useRayWithElement } from 'react-ray';
+import { useRef, useState } from 'react';
+
+const MyComponent = () => {
+    const [count, setCount] = useState(0);
+    const countRef = useRef(null);
+
+    useRayWithElement(countRef, [count], { replace: false });
+
+    return (
+        <div>
+            <div ref={countRef}>{count}</div>
+            <button onClick={() => setCount(count + 1)}>
+                Click me
+            </button>
+        </div>
+    );
+};
+```
+
+To update the Ray item in place that was sent with the contents of a ref when its dependencies change, set the `replace` option to true or omit it:
+
+```js
+import { useRayWithElement } from 'react-ray';
+import { useRef, useState } from 'react';
+
+const MyComponent = () => {
+    const [count, setCount] = useState(0);
+    const countRef = useRef(null);
+
+    useRayWithElement(countRef, [count], { replace: true });
+    // or
+    // useRayWithElement(countRef, [count]);
+
+    return (
+        <div>
+            <div ref={countRef}>{count}</div>
+            <button onClick={() => setCount(count + 1)}>
+                Click me
+            </button>
+        </div>
+    );
+};
+```


### PR DESCRIPTION
This PR adds documentation for the [react-ray](https://github.com/permafrost-dev/react-ray) package, which is an integration for Ray and React v16+.

The `react-ray` integration provides several hooks for use within React that allow the sending of data to Ray while conforming to React's design patterns.