### PR TITLE
adding support for calling closures before doing a ray request

### DIFF
--- a/src/Ray.php
+++ b/src/Ray.php
@@ -817,7 +817,7 @@ class Ray
         ], $meta);
 
         if ($closure = static::$beforeSendRequest) {
-            $closure($payloads, $meta);
+            $closure($payloads, $allMeta);
         }
 
         foreach ($payloads as $payload) {

--- a/src/Ray.php
+++ b/src/Ray.php
@@ -104,6 +104,9 @@ class Ray
     /** @var string */
     public static $projectName = '';
 
+    /** @var Closure|null */
+    public static ?Closure $beforeSendRequest = null;
+
     public static function create(Client $client = null, string $uuid = null): self
     {
         $settings = SettingsFactory::createFromConfigFile();
@@ -813,6 +816,10 @@ class Ray
             'project_name' => static::$projectName,
         ], $meta);
 
+        if ($closure = static::$beforeSendRequest) {
+            $closure($payloads, $meta);
+        }
+
         foreach ($payloads as $payload) {
             $payload->remotePath = $this->settings->remote_path;
             $payload->localPath = $this->settings->local_path;
@@ -850,5 +857,10 @@ class Ray
         self::$client->send($request);
 
         self::rateLimiter()->notify();
+    }
+
+    public static function beforeSendRequest(Closure $closure): void
+    {
+        static::$beforeSendRequest = $closure;
     }
 }

--- a/src/Ray.php
+++ b/src/Ray.php
@@ -859,7 +859,7 @@ class Ray
         self::rateLimiter()->notify();
     }
 
-    public static function beforeSendRequest(Closure $closure): void
+    public static function beforeSendRequest(null|Closure $closure): void
     {
         static::$beforeSendRequest = $closure;
     }

--- a/src/Ray.php
+++ b/src/Ray.php
@@ -105,7 +105,7 @@ class Ray
     public static $projectName = '';
 
     /** @var Closure|null */
-    public static ?Closure $beforeSendRequest = null;
+    public static null|Closure $beforeSendRequest = null;
 
     public static function create(Client $client = null, string $uuid = null): self
     {

--- a/src/Ray.php
+++ b/src/Ray.php
@@ -105,7 +105,7 @@ class Ray
     public static $projectName = '';
 
     /** @var Closure|null */
-    public static null|Closure $beforeSendRequest = null;
+    public static Closure|null $beforeSendRequest = null;
 
     public static function create(Client $client = null, string $uuid = null): self
     {
@@ -859,7 +859,7 @@ class Ray
         self::rateLimiter()->notify();
     }
 
-    public static function beforeSendRequest(null|Closure $closure): void
+    public static function beforeSendRequest(Closure|null $closure): void
     {
         static::$beforeSendRequest = $closure;
     }

--- a/src/Ray.php
+++ b/src/Ray.php
@@ -105,7 +105,7 @@ class Ray
     public static $projectName = '';
 
     /** @var Closure|null */
-    public static Closure|null $beforeSendRequest = null;
+    public static $beforeSendRequest = null;
 
     public static function create(Client $client = null, string $uuid = null): self
     {
@@ -859,7 +859,7 @@ class Ray
         self::rateLimiter()->notify();
     }
 
-    public static function beforeSendRequest(Closure|null $closure): void
+    public static function beforeSendRequest(?Closure $closure = null): void
     {
         static::$beforeSendRequest = $closure;
     }

--- a/tests/RayTest.php
+++ b/tests/RayTest.php
@@ -1176,3 +1176,17 @@ it('it has a method to expand everything', function () {
 
     expect($sentRequests[0]['payloads'][0]['content']['level'])->toBe(999);
 });
+
+it('can add a closure for before send and actually calls it', function () {
+    $this->closureCalled = false;
+
+    $this->ray::beforeSendRequest(function () {
+        $this->closureCalled = true;
+    });
+
+    $this->ray->send(function ($ray) {
+        $ray->text('Hello world');
+    });
+
+    expect($this->closureCalled)->toBeTrue();
+});


### PR DESCRIPTION
I want to call an Apple Script to start Ray if not already active before doing any requests to Ray.

With the PR you would be able to add this to your service provider

```php
use Spatie\Ray\Ray;

Ray::beforeSendRequest(function () {
    $script = '
        set appBundleID to "be.spatie.ray"

        tell application "System Events"
            if not (exists (processes whose bundle identifier is appBundleID)) then
                tell application "Ray" to activate
                delay 1
            end if
        end tell
    ';

    $escapedScript = escapeshellarg($script);
    $command = "osascript -e $escapedScript";

    $output = shell_exec($command);
});
```