### PR TITLE
Implement cURL Handle Caching

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -19,6 +19,9 @@ class Client
     /** @var string */
     protected $fingerprint;
 
+    /** @var mixed */
+    protected $curlHandle;
+
     public function __construct(int $portNumber = 23517, string $host = 'localhost')
     {
         $this->fingerprint = $host . ':' . $portNumber;
@@ -74,7 +77,7 @@ class Client
 
             $curlError = null;
 
-            curl_setopt($curlHandle, CURLOPT_POSTFIELDS, $request->toJson());
+            curl_setopt($this->curlHandle, CURLOPT_POSTFIELDS, $request->toJson());
             curl_exec($curlHandle);
 
             if (curl_errno($curlHandle)) {
@@ -145,28 +148,31 @@ class Client
 
     protected function getCurlHandle(string $method, string $fullUrl)
     {
-        $curlHandle = curl_init();
+        if (!$this->curlHandle) {
+            $this->curlHandle = curl_init();
+        }
 
-        curl_setopt($curlHandle, CURLOPT_URL, $fullUrl);
+        curl_reset($this->curlHandle);
+        curl_setopt($this->curlHandle, CURLOPT_URL, $fullUrl);
 
-        curl_setopt($curlHandle, CURLOPT_HTTPHEADER, array_merge([
+        curl_setopt($this->curlHandle, CURLOPT_HTTPHEADER, array_merge([
             'Accept: application/json',
             'Content-Type: application/json',
         ]));
 
-        curl_setopt($curlHandle, CURLOPT_USERAGENT, 'Ray 1.0');
-        curl_setopt($curlHandle, CURLOPT_RETURNTRANSFER, true);
-        curl_setopt($curlHandle, CURLOPT_TIMEOUT, 2);
-        curl_setopt($curlHandle, CURLOPT_SSL_VERIFYPEER, true);
-        curl_setopt($curlHandle, CURLOPT_HTTP_VERSION, CURL_HTTP_VERSION_1_1);
-        curl_setopt($curlHandle, CURLOPT_ENCODING, '');
-        curl_setopt($curlHandle, CURLINFO_HEADER_OUT, true);
-        curl_setopt($curlHandle, CURLOPT_FAILONERROR, true);
+        curl_setopt($this->curlHandle, CURLOPT_USERAGENT, 'Ray 1.0');
+        curl_setopt($this->curlHandle, CURLOPT_RETURNTRANSFER, true);
+        curl_setopt($this->curlHandle, CURLOPT_TIMEOUT, 2);
+        curl_setopt($this->curlHandle, CURLOPT_SSL_VERIFYPEER, true);
+        curl_setopt($this->curlHandle, CURLOPT_HTTP_VERSION, CURL_HTTP_VERSION_1_1);
+        curl_setopt($this->curlHandle, CURLOPT_ENCODING, '');
+        curl_setopt($this->curlHandle, CURLINFO_HEADER_OUT, true);
+        curl_setopt($this->curlHandle, CURLOPT_FAILONERROR, true);
 
         if ($method === 'post') {
-            curl_setopt($curlHandle, CURLOPT_POST, true);
+            curl_setopt($this->curlHandle, CURLOPT_POST, true);
         }
 
-        return $curlHandle;
+        return $this->curlHandle;
     }
 }


### PR DESCRIPTION
This PR implements caching of the cURL handle created by `curl_init()` to increase performance and reduce system overhead that comes with repeated creation and destruction of curl handles. 

It modifies the `getCurlHandle()` method and only calls `curl_init()` once instead of each call to `send()`. It also removes now unnecessary calls to `curl_close()` in order to retain the pointer to the cached handle. 

Calls to `curl_init` call `curl_easy_init` under the hood - the `cURL` documentation for `curl_easy_init` says "[You are]...encouraged to reuse easy handles for repeated transfers..." (see https://curl.se/libcurl/c/curl_easy_init.html).  This PR implements this suggestion. The documentation for cURL also states "...reusing handles is a key to good performance with libcurl."

@patinthehat 