### PR TITLE
Fixes `Typed property Symfony\Component\VarDumper\Dumper\CliDumper::$colors must not be accessed before initialization`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "spatie/backtrace": "^1.1",
         "spatie/macroable": "^1.0|^2.0",
         "symfony/stopwatch": "^4.0|^5.1|^6.0|^7.0",
-        "symfony/var-dumper": "^4.2|^5.1|^6.0|^7.0"
+        "symfony/var-dumper": "^4.2|^5.1|^6.0|^7.0.3"
     },
     "require-dev": {
         "illuminate/support": "6.x|^8.18|^9.0",


### PR DESCRIPTION
Relevant commit: [https://github.com/symfony/var-dumper/commit/6e1761053eaaaca46c0e0d959f7c6c466ca29ac7](https://github.com/symfony/var-dumper/commit/6e1761053eaaaca46c0e0d959f7c6c466ca29ac7)