### PR TITLE
Make implicit nullable param to explicit (PHP 8.4 compatibility)

### DIFF
--- a/src/Ray.php
+++ b/src/Ray.php
@@ -107,14 +107,14 @@ class Ray
     /** @var Closure|null */
     public static $beforeSendRequest = null;
 
-    public static function create(Client $client = null, string $uuid = null): self
+    public static function create(?Client $client = null, string $uuid = null): self
     {
         $settings = SettingsFactory::createFromConfigFile();
 
         return new static($settings, $client, $uuid);
     }
 
-    public function __construct(Settings $settings, Client $client = null, string $uuid = null)
+    public function __construct(Settings $settings, ?Client $client = null, ?string $uuid = null)
     {
         $this->settings = $settings;
 

--- a/src/Settings/SettingsFactory.php
+++ b/src/Settings/SettingsFactory.php
@@ -11,7 +11,7 @@ class SettingsFactory
         return new Settings($settings);
     }
 
-    public static function createFromConfigFile(string $configDirectory = null): Settings
+    public static function createFromConfigFile(?string $configDirectory = null): Settings
     {
         $settingValues = (new static())->getSettingsFromConfigFile($configDirectory);
 
@@ -24,7 +24,7 @@ class SettingsFactory
         return $settings;
     }
 
-    public function getSettingsFromConfigFile(string $configDirectory = null): array
+    public function getSettingsFromConfigFile(?string $configDirectory = null): array
     {
         $configFilePath = $this->searchConfigFiles($configDirectory);
 
@@ -37,7 +37,7 @@ class SettingsFactory
         return $options ?? [];
     }
 
-    protected function searchConfigFiles(string $configDirectory = null): string
+    protected function searchConfigFiles(?string $configDirectory = null): string
     {
         if (! isset(self::$cache[$configDirectory])) {
             self::$cache[$configDirectory] = $this->searchConfigFilesOnDisk($configDirectory);
@@ -46,7 +46,7 @@ class SettingsFactory
         return self::$cache[$configDirectory];
     }
 
-    protected function searchConfigFilesOnDisk(string $configDirectory = null): string
+    protected function searchConfigFilesOnDisk(?string $configDirectory = null): string
     {
         $configNames = [
             'ray.php',

--- a/tests/TestClasses/FakeClock.php
+++ b/tests/TestClasses/FakeClock.php
@@ -10,7 +10,7 @@ class FakeClock implements Clock
     /** @var DateTimeImmutable|null */
     protected $fixedNow;
 
-    public function __construct(DateTimeImmutable $now = null)
+    public function __construct(?DateTimeImmutable $now = null)
     {
         $this->fixedNow = $now;
     }
@@ -20,7 +20,7 @@ class FakeClock implements Clock
         return $this->fixedNow ?? new DateTimeImmutable();
     }
 
-    public function freeze(DateTimeImmutable $now = null): void
+    public function freeze(?DateTimeImmutable $now = null): void
     {
         $this->fixedNow = $now ?? new DateTimeImmutable();
     }


### PR DESCRIPTION
Implicitly nullable parameter declarations are deprecated in PHP 8.4 ([ref](https://php.watch/versions/8.4/implicitly-marking-parameter-type-nullable-deprecated)).

Same as https://github.com/spatie/laravel-ray/pull/340.

_Sorry for the fragmented PRs, I haven't setup the PHP 8.4 dev env yet, I'm relying on the CI._