### PR TITLE
Add support for PHPStan 2.0

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -9,7 +9,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest]
-        php: [8.2, 8.1, 8.0, 7.4, 7.3]
+        php: [8.3, 8.2, 8.1, 8.0, 7.4]
         dependency-version: [prefer-lowest, prefer-stable]
 
     name: P${{ matrix.php }} - ${{ matrix.dependency-version }} - ${{ matrix.os }}

--- a/composer.json
+++ b/composer.json
@@ -26,17 +26,17 @@
         }
     ],
     "require": {
-        "php": "^7.3 || ^8.0",
+        "php": "^7.4 || ^8.0",
         "ext-curl": "*",
         "ext-json": "*",
         "ramsey/uuid": "^3.0 || ^4.1",
         "spatie/backtrace": "^1.1",
         "spatie/macroable": "^1.0 || ^2.0",
-        "symfony/stopwatch": "^4.0 || ^5.1 || ^6.0 || ^7.0",
+        "symfony/stopwatch": "^4.2 || ^5.1 || ^6.0 || ^7.0",
         "symfony/var-dumper": "^4.2 || ^5.1 || ^6.0 || ^7.0.3"
     },
     "require-dev": {
-        "illuminate/support": "6.x || ^7.20 || ^8.18 || ^9.0 || ^10.0 || ^11.0",
+        "illuminate/support": "^7.20 || ^8.18 || ^9.0 || ^10.0 || ^11.0",
         "nesbot/carbon": "^2.63",
         "pestphp/pest": "^1.22",
         "phpstan/phpstan": "^1.10.57 || ^2.0.2",

--- a/composer.json
+++ b/composer.json
@@ -1,12 +1,11 @@
 {
     "name": "spatie/ray",
     "description": "Debug with Ray to fix problems faster",
+    "license": "MIT",
     "keywords": [
         "spatie",
         "ray"
     ],
-    "homepage": "https://github.com/spatie/ray",
-    "license": "MIT",
     "authors": [
         {
             "name": "Freek Van der Herten",
@@ -15,29 +14,39 @@
             "role": "Developer"
         }
     ],
-    "bin": [
-        "bin/remove-ray.sh"
+    "homepage": "https://github.com/spatie/ray",
+    "funding": [
+        {
+            "type": "github",
+            "url": "https://github.com/sponsors/spatie"
+        },
+        {
+            "type": "other",
+            "url": "https://spatie.be/open-source/support-us"
+        }
     ],
     "require": {
-        "php": "^7.3|^8.0",
+        "php": "^7.3 || ^8.0",
         "ext-curl": "*",
         "ext-json": "*",
-        "ramsey/uuid": "^3.0|^4.1",
+        "ramsey/uuid": "^3.0 || ^4.1",
         "spatie/backtrace": "^1.1",
-        "spatie/macroable": "^1.0|^2.0",
-        "symfony/stopwatch": "^4.0|^5.1|^6.0|^7.0",
-        "symfony/var-dumper": "^4.2|^5.1|^6.0|^7.0.3"
+        "spatie/macroable": "^1.0 || ^2.0",
+        "symfony/stopwatch": "^4.0 || ^5.1 || ^6.0 || ^7.0",
+        "symfony/var-dumper": "^4.2 || ^5.1 || ^6.0 || ^7.0.3"
     },
     "require-dev": {
-        "illuminate/support": "6.x|^8.18|^9.0",
+        "illuminate/support": "6.x || ^7.20 || ^8.18 || ^9.0 || ^10.0 || ^11.0",
         "nesbot/carbon": "^2.63",
         "pestphp/pest": "^1.22",
-        "phpstan/phpstan": "^1.10",
+        "phpstan/phpstan": "^1.10.57 || ^2.0.2",
         "phpunit/phpunit": "^9.5",
-        "rector/rector": "^0.19.2",
+        "rector/rector": "dev-main",
         "spatie/phpunit-snapshot-assertions": "^4.2",
         "spatie/test-time": "^1.2"
     },
+    "minimum-stability": "dev",
+    "prefer-stable": true,
     "autoload": {
         "psr-4": {
             "Spatie\\Ray\\": "src"
@@ -51,33 +60,24 @@
             "Spatie\\Ray\\Tests\\": "tests"
         }
     },
-    "scripts": {
-        "test": "vendor/bin/pest",
-        "test-coverage": "vendor/bin/pest --coverage",
-        "format": "vendor/bin/php-cs-fixer fix --allow-risky=yes",
-        "phpstan": "vendor/bin/phpstan analyse"
-    },
+    "bin": [
+        "bin/remove-ray.sh"
+    ],
     "config": {
-        "sort-packages": true,
         "allow-plugins": {
             "pestphp/pest-plugin": true
-        }
+        },
+        "sort-packages": true
     },
     "extra": {
         "branch-alias": {
             "dev-main": "1.x-dev"
         }
     },
-    "minimum-stability": "dev",
-    "prefer-stable": true,
-    "funding": [
-        {
-            "type": "github",
-            "url": "https://github.com/sponsors/spatie"
-        },
-        {
-            "type": "other",
-            "url": "https://spatie.be/open-source/support-us"
-        }
-    ]
+    "scripts": {
+        "format": "vendor/bin/php-cs-fixer fix --allow-risky=yes",
+        "phpstan": "vendor/bin/phpstan analyse",
+        "test": "vendor/bin/pest",
+        "test-coverage": "vendor/bin/pest --coverage"
+    }
 }

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -11,4 +11,4 @@ parameters:
 		- '#Unsafe usage of new static\(\)#'
 		-
 		    message: '#Undefined variable\: \$this#'
-		    path: test
+		    path: tests

--- a/src/PHPStan/RemainingRayCallRule.php
+++ b/src/PHPStan/RemainingRayCallRule.php
@@ -20,7 +20,7 @@ class RemainingRayCallRule implements Rule
             return [];
         }
 
-        if ($node->name->parts[0] !== 'ray') {
+        if ($node->name->getParts()[0] !== 'ray') {
             return [];
         }
 

--- a/src/Payloads/ExpandPayload.php
+++ b/src/Payloads/ExpandPayload.php
@@ -12,7 +12,7 @@ class ExpandPayload extends Payload
 
     public function __construct(array $values = [])
     {
-        foreach($values as $value) {
+        foreach ($values as $value) {
             if (is_numeric($value)) {
                 $this->level = max($this->level, $value);
 

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -4,7 +4,6 @@ use Illuminate\Contracts\Container\BindingResolutionException;
 use Spatie\CraftRay\Ray as CraftRay;
 use Spatie\LaravelRay\Ray as LaravelRay;
 use Spatie\Ray\Ray;
-
 use Spatie\Ray\Settings\SettingsFactory;
 use Spatie\RayBundle\Ray as SymfonyRay;
 use Spatie\WordPressRay\Ray as WordPressRay;

--- a/tests/PayloadFactoryTest.php
+++ b/tests/PayloadFactoryTest.php
@@ -2,8 +2,6 @@
 
 use Carbon\Carbon;
 use Carbon\CarbonImmutable;
-
-
 use Spatie\Ray\PayloadFactory;
 use Spatie\Ray\Payloads\CarbonPayload;
 

--- a/tests/RayTest.php
+++ b/tests/RayTest.php
@@ -2,12 +2,8 @@
 
 use Carbon\Carbon;
 use Illuminate\Support\Arr;
-
-
 use Spatie\Backtrace\Frame;
-
 use Spatie\Ray\Origin\Hostname;
-
 use Spatie\Ray\PayloadFactory;
 use Spatie\Ray\Payloads\CallerPayload;
 use Spatie\Ray\Payloads\LogPayload;


### PR DESCRIPTION
Currently anyone wishing to use PHPStan 2.0 / LaraStan 3.0 are unable to utilise the awesome sauce of Spatie Ray. This is related to package `rector/rector`, which currently no release tagged for PHPStan 2.0 yet. But it's in the testing phase see the open issue for more details https://github.com/rectorphp/rector/issues/8815#issuecomment-2493467044

Please note once the release has been tagged and released for `rector/rector` I will update this PR with the tags correctly for the `rector/rector` in the `composer.json` file.

Bumps the minimum PHP from `7.3` to `7.4` to match that of the Laravel Ray package and updated the workflows to match this change.

Related to https://github.com/spatie/laravel-ray/pull/367