### PR TITLE
Update Dependencies

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -38,6 +38,10 @@ jobs:
         run: composer require "illuminate/support:8.*" --no-interaction --no-update
         if: matrix.php == '8.2' && matrix.dependency-version == 'prefer-lowest'
 
+      - name: Configure for PHP 8.4
+        run: composer require "rector/rector:2.*" --no-interaction --no-update
+        if: matrix.php == '8.4' && matrix.dependency-version == 'prefer-lowest'
+
       - name: Install dependencies
         run: composer update --${{ matrix.dependency-version }} --prefer-dist --no-interaction
 

--- a/composer.json
+++ b/composer.json
@@ -41,7 +41,7 @@
         "pestphp/pest": "^1.22",
         "phpstan/phpstan": "^1.10.57 || ^2.0.3",
         "phpunit/phpunit": "^9.5",
-        "rector/rector": "dev-main",
+        "rector/rector": "^0.19.2 || ^1.0.1 || ^2.0.0-rc2",
         "spatie/phpunit-snapshot-assertions": "^4.2",
         "spatie/test-time": "^1.2"
     },

--- a/composer.json
+++ b/composer.json
@@ -41,7 +41,7 @@
         "pestphp/pest": "^1.22",
         "phpstan/phpstan": "^1.10.57 || ^2.0.2",
         "phpunit/phpunit": "^9.5",
-        "rector/rector": "dev-main",
+        "rector/rector": "^0.19.2 || ^2.0.0-rc1",
         "spatie/phpunit-snapshot-assertions": "^4.2",
         "spatie/test-time": "^1.2"
     },

--- a/composer.json
+++ b/composer.json
@@ -39,9 +39,9 @@
         "illuminate/support": "^7.20 || ^8.18 || ^9.0 || ^10.0 || ^11.0",
         "nesbot/carbon": "^2.63",
         "pestphp/pest": "^1.22",
-        "phpstan/phpstan": "^1.10.57 || ^2.0.2",
+        "phpstan/phpstan": "^1.10.57 || ^2.0.3",
         "phpunit/phpunit": "^9.5",
-        "rector/rector": "^0.19.2 || ^2.0.0-rc1",
+        "rector/rector": "dev-main",
         "spatie/phpunit-snapshot-assertions": "^4.2",
         "spatie/test-time": "^1.2"
     },

--- a/composer.json
+++ b/composer.json
@@ -41,7 +41,7 @@
         "pestphp/pest": "^1.22",
         "phpstan/phpstan": "^1.10.57 || ^2.0.3",
         "phpunit/phpunit": "^9.5",
-        "rector/rector": "^0.19.2 || ^1.0.1 || ^2.0.0-rc2",
+        "rector/rector": "^0.19.2 || ^1.0.1 || ^2.0.0",
         "spatie/phpunit-snapshot-assertions": "^4.2",
         "spatie/test-time": "^1.2"
     },

--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
         "ext-curl": "*",
         "ext-json": "*",
         "ramsey/uuid": "^3.0 || ^4.1",
-        "spatie/backtrace": "^1.1",
+        "spatie/backtrace": "^1.7.1",
         "spatie/macroable": "^1.0 || ^2.0",
         "symfony/stopwatch": "^4.2 || ^5.1 || ^6.0 || ^7.0",
         "symfony/var-dumper": "^4.2 || ^5.1 || ^6.0 || ^7.0.3"


### PR DESCRIPTION
This pull request includes updates to the PHP dependencies and configuration for running tests. The most important changes are listed below:

### Dependency Updates:

* Updated `spatie/backtrace` to version `^1.7.1` in `composer.json` this introduced PHP 8.4 deprecation notice fixes.
* Updated `phpstan/phpstan` to version `^1.10.57 || ^2.0.3` in `composer.json`.
* Updated `rector/rector` to version `^0.19.2 || ^1.0.1 || ^2.0.0` in `composer.json`.

### Workflow Fix:
* PHP 8.4 `prefer-lowest` to be fixed with minimum `rector/rector` version of `2.0`

Related to PR https://github.com/spatie/laravel-ray/pull/369