### PR TITLE
Use static:: instead of self:: for late static binding

### DIFF
--- a/src/Payloads/Payload.php
+++ b/src/Payloads/Payload.php
@@ -51,7 +51,7 @@ abstract class Payload
     protected function getOrigin(): Origin
     {
         /** @var \Spatie\Ray\Origin\OriginFactory $originFactory */
-        $originFactory = new self::$originFactoryClass();
+        $originFactory = new static::$originFactoryClass();
 
         $origin = $originFactory->getOrigin();
 


### PR DESCRIPTION
Replaced `self::$originFactoryClass` with `static::$originFactoryClass` to enable late static binding. This ensures that subclasses correctly use their _own_ originFactoryClass instead of always referring to the `abstract Payload` class.