### PR TITLE
Add offset and limit support to trace

### DIFF
--- a/src/Ray.php
+++ b/src/Ray.php
@@ -275,7 +275,7 @@ class Ray
         return $this->sendRequest($payload);
     }
 
-    public function trace(?Closure $startingFromFrame = null): self
+    public function trace(?Closure $startingFromFrame = null, ?int $offset = null, ?int $limit = null): self
     {
         $backtrace = Backtrace::create();
 
@@ -287,14 +287,22 @@ class Ray
             $backtrace->startingFromFrame($startingFromFrame);
         }
 
+        if ($offset) {
+            $backtrace->offset($offset);
+        }
+
+        if ($limit) {
+            $backtrace->limit($limit);
+        }
+
         $payload = new TracePayload($backtrace->frames());
 
         return $this->sendRequest($payload);
     }
 
-    public function backtrace(?Closure $startingFromFrame = null): self
+    public function backtrace(?Closure $startingFromFrame = null, ?int $offset = null, ?int $limit = null): self
     {
-        return $this->trace($startingFromFrame);
+        return $this->trace($startingFromFrame, $offset, $limit);
     }
 
     public function caller(): self

--- a/tests/RayTest.php
+++ b/tests/RayTest.php
@@ -260,6 +260,33 @@ it('can send backtrace frames starting from a specific frame', function () {
     expect($firstFrame['method'])->toEqual('run');
 });
 
+it('can send backtrace frames with a max limit of frames', function () {
+    $this->ray->trace(null, null, 4);
+    $frames = getValueOfLastSentContent('frames');
+
+    expect(count($frames))->toBeLessThanOrEqual(4);
+
+    $lastFrame = $frames[count($frames) - 1];
+
+    expect($lastFrame['class'])->toEqual('P\Tests\RayTest');
+    expect($lastFrame['method'])->toContain('{closure');
+});
+
+it('can send backtrace frames skipping the first x frames', function () {
+    $this->ray->trace();
+    $allFrames = getValueOfLastSentContent('frames');
+
+    $this->ray->trace(null, 3);
+    $frames = getValueOfLastSentContent('frames');
+
+    expect(count($frames))->toBeLessThan(count($allFrames));
+
+    $firstFrame = $frames[0];
+
+    expect($firstFrame['class'])->toEqual('P\Tests\RayTest');
+    expect($firstFrame['method'])->toContain('{closure');
+});
+
 it('has a backtrace alias for trace', function () {
     $this->ray->backtrace();
     $frames = getValueOfLastSentContent('frames');


### PR DESCRIPTION
`trace` uses `https://github.com/spatie/backtrace` to properly output the current backtrace. Unfortunately the offset and limit features of `backtrace` are not implemented. This PR solves that.

You can then call `ray()->backtrace(limit: 10, offset: 20)` to send only a subset of frames.