### PR TITLE
Fix searchConfigFilesOnDisk to handle empty string parameter

### DIFF
--- a/src/Settings/SettingsFactory.php
+++ b/src/Settings/SettingsFactory.php
@@ -53,7 +53,7 @@ class SettingsFactory
             'ray.php',
         ];
 
-        $configDirectory = $configDirectory ?? getcwd();
+        $configDirectory = $configDirectory ?: getcwd();
 
         while (@is_dir($configDirectory)) {
             foreach ($configNames as $configName) {


### PR DESCRIPTION
Fixes regression from 916d467 where converting null to empty string in searchConfigFiles() broke the ?? operator fallback in searchConfigFilesOnDisk().

Use elvis operator instead to handle both null and empty string.